### PR TITLE
Add analytics worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 .astro/
 .DS_Store
 *.log
+.dev.vars
+.wrangler/

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,0 +1,40 @@
+export interface Env {
+  ASSETS: { fetch: (request: Request) => Promise<Response> };
+  POSTHOG_KEY: string;
+}
+
+export default {
+  async fetch(
+    request: Request,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<Response> {
+    const url = new URL(request.url);
+    const ip = request.headers.get("cf-connecting-ip") || "unknown";
+    const country = request.headers.get("cf-ipcountry") || "unknown";
+    const agent = request.headers.get("user-agent") || "unknown";
+    if (agent.includes("executor")) {
+      ctx.waitUntil(
+        fetch("https://us.i.posthog.com/i/v0/e/", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            api_key: env.POSTHOG_KEY,
+            event: "hit",
+            distinct_id: ip,
+            properties: {
+              $process_person_profile: false,
+              user_agent: agent,
+              country,
+              path: url.pathname,
+            },
+          }),
+        }),
+      );
+    }
+
+    return await env.ASSETS.fetch(request);
+  },
+};

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,10 +1,13 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "integrationsdotsh",
+  "main": "./worker/index.ts",
   "compatibility_date": "2025-04-01",
   "workers_dev": true,
   "assets": {
     "directory": "./dist",
+    "binding": "ASSETS",
+    "run_worker_first": true,
     "not_found_handling": "404-page"
   },
   "routes": [


### PR DESCRIPTION
## Summary
- Adds a Cloudflare Worker that records a PostHog `hit` event when the request user-agent contains `executor`
- Worker runs first via `run_worker_first` and falls through to the static assets binding for everything else, so browser traffic is unchanged
- Local dev reads `POSTHOG_KEY` from a gitignored `.dev.vars`; production uses a Wrangler secret of the same name

## Test plan
- [ ] `bun install && bunx wrangler dev` → site loads as before in a browser
- [ ] `curl -A "executor/test/0.0.0/cli" http://127.0.0.1:8787/api.json` → 200 OK; event appears in PostHog within ~30s
- [ ] `curl -A "curl/8.0" http://127.0.0.1:8787/api.json` → 200 OK, no PostHog event (UA filter)
- [ ] `wrangler secret put POSTHOG_KEY` set in prod before `bunx wrangler deploy`