### PR TITLE
Analytics: client-side PostHog behind a first-party /_i proxy, broader server events

### DIFF
--- a/src/components/Surfaces.tsx
+++ b/src/components/Surfaces.tsx
@@ -232,6 +232,9 @@ export default function Surfaces({ domain, catalog }: { domain: string; catalog:
   }, [domain]);
 
   async function run() {
+    // The site's key conversion — posthog is the snippet global from chrome.ts
+    // (absent on localhost, hence the guard).
+    (window as { posthog?: { capture: (e: string, p?: Record<string, unknown>) => void } }).posthog?.capture("map_surface_clicked", { domain });
     setState("loading");
     setProgress("Starting…");
     setLiveCreds({});

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,6 +1,6 @@
 ---
 import { stars } from "~/lib/github.ts";
-import { GLOBAL_CSS, FONT_HEAD, navHtml, footerHtml, FOOTER_JS } from "~/lib/chrome.ts";
+import { GLOBAL_CSS, FONT_HEAD, navHtml, footerHtml, FOOTER_JS, ANALYTICS_JS } from "~/lib/chrome.ts";
 
 interface Props {
   title: string;
@@ -34,6 +34,7 @@ const canonical = path ? new URL(path, Astro.site).href : undefined;
     <link rel="icon" type="image/svg+xml" href="/favicon-light.svg" media="(prefers-color-scheme: dark)" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <Fragment set:html={FONT_HEAD} />
+    <script is:inline set:html={ANALYTICS_JS} />
     <!-- Shared chrome — single source of truth in src/lib/chrome.ts, also used
          by the worker-rendered surface pages so they never drift. -->
     <style is:global set:html={GLOBAL_CSS}></style>

--- a/src/lib/chrome.ts
+++ b/src/lib/chrome.ts
@@ -12,6 +12,22 @@
 
 export const REPO_URL = "https://github.com/UsefulSoftwareCo/integrationsdotsh";
 
+/** PostHog project token for the integrations.sh project (public by design —
+ * it can only ingest, not read). Server-side events in the worker use the
+ * POSTHOG_KEY secret, which must hold this same token. */
+export const POSTHOG_TOKEN = "phc_n2pqszLvoefgiTmM9mhXUgx9hX8K5ESw7Wh2NmR83ftb";
+
+/**
+ * Client analytics — the official posthog-js loader, pointed at our own
+ * `/_i/*` worker route (first-party proxy → not eaten by tracker blockers;
+ * see worker/index.ts). Skipped on localhost so dev sessions stay out of the
+ * data. Emitted as a real inline <script> by every consumer (set:html-injected
+ * scripts don't run), same as FOOTER_JS.
+ */
+export const ANALYTICS_JS =
+  `!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);` +
+  `if(!/^(localhost$|127\\.|0\\.0\\.0\\.0$)/.test(location.hostname))posthog.init("${POSTHOG_TOKEN}",{api_host:"/_i",ui_host:"https://us.posthog.com",defaults:"2026-05-30"});`;
+
 /** Compact star count, e.g. 1234 -> "1.2k". Mirrors github.ts.formatStars. */
 export const formatStars = (n: number): string => (n >= 1000 ? `${(n / 1000).toFixed(1).replace(/\.0$/, "")}k` : String(n));
 

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -110,6 +110,31 @@ const json = (body: unknown, status = 200, headers: Record<string, string> = {})
     headers: { "content-type": "application/json; charset=utf-8", "access-control-allow-origin": "*", ...headers },
   });
 
+/** Fire-and-forget server-side PostHog capture. Browser pageviews come from
+ * posthog-js (ANALYTICS_JS in chrome.ts); this covers the callers that never
+ * run JS — agents fetching data files, MCP clients, and direct API users. */
+function track(env: Env, ctx: ExecutionContext, request: Request, event: string, properties: Record<string, unknown> = {}): void {
+  if (!env.POSTHOG_KEY) return;
+  ctx.waitUntil(
+    fetch("https://us.i.posthog.com/i/v0/e/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        api_key: env.POSTHOG_KEY,
+        event,
+        distinct_id: request.headers.get("cf-connecting-ip") || "unknown",
+        properties: {
+          $process_person_profile: false,
+          user_agent: request.headers.get("user-agent") || "unknown",
+          country: request.headers.get("cf-ipcountry") || "unknown",
+          path: new URL(request.url).pathname,
+          ...properties,
+        },
+      }),
+    }).catch(() => {}),
+  );
+}
+
 export default {
   async fetch(
     request: Request,
@@ -119,9 +144,27 @@ export default {
     const url = new URL(request.url);
     wireAi(env);
 
+    // First-party analytics proxy — posthog-js points api_host here (see
+    // ANALYTICS_JS in chrome.ts), so ingestion is same-origin and survives
+    // tracker blocklists. Static assets (array.js) come from the assets host;
+    // everything else goes to ingestion. Pass the client IP through so PostHog
+    // geolocates the visitor rather than the Cloudflare edge.
+    if (url.pathname.startsWith("/_i/")) {
+      const upstream = url.pathname.startsWith("/_i/static/")
+        ? "https://us-assets.i.posthog.com"
+        : "https://us.i.posthog.com";
+      const target = new URL(url.pathname.slice(3) + url.search, upstream);
+      const headers = new Headers(request.headers);
+      headers.delete("cookie");
+      const ip = request.headers.get("cf-connecting-ip");
+      if (ip) headers.set("x-forwarded-for", ip);
+      return fetch(new Request(target, { method: request.method, headers, body: request.body, redirect: "follow" }));
+    }
+
     // MCP server — point Claude/Cursor at /mcp. Routed through a single Durable
     // Object so the session map persists across stateless Worker requests.
     if (url.pathname === "/mcp") {
+      track(env, ctx, request, "mcp_request");
       return env.MCP.get(env.MCP.idFromName("mcp")).fetch(request);
     }
 
@@ -175,6 +218,7 @@ export default {
       const producer = (async () => {
         try {
           const cached = await cache.match(cacheKey);
+          track(env, ctx, request, "discovery_run", { domain, cached: !!cached });
           if (cached) {
             const result = (await cached.json()) as { domain?: string };
             await send("done", result);
@@ -219,6 +263,7 @@ export default {
     // Dynamic API (the Effect HttpApi) — detect, discover + the OpenAPI doc.
     // Other /api/* paths (e.g. the static /api/domains.json) fall through to assets.
     if (url.pathname === "/openapi.json" || /^\/api\/[^/]+\/(?:detect|discover)\/?$/.test(url.pathname)) {
+      track(env, ctx, request, "api_request");
       const cache = (caches as unknown as { default: Cache }).default;
       // Version the cache key so a deploy that bumps CACHE_VERSION orphans stale
       // entries (the Cache API otherwise survives deploys).
@@ -273,23 +318,16 @@ export default {
       }
     }
 
-    // Analytics: count executor-agent hits.
-    const ip = request.headers.get("cf-connecting-ip") || "unknown";
-    const country = request.headers.get("cf-ipcountry") || "unknown";
+    // Analytics on asset fallthrough: `hit` for executor agents (kept as-is —
+    // pre-launch dashboards query it), `data_fetch` for any non-browser caller
+    // pulling the machine-readable files. Browser pageviews are client-side.
     const agent = request.headers.get("user-agent") || "unknown";
     if (agent.includes("executor")) {
-      ctx.waitUntil(
-        fetch("https://us.i.posthog.com/i/v0/e/", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            api_key: env.POSTHOG_KEY,
-            event: "hit",
-            distinct_id: ip,
-            properties: { $process_person_profile: false, user_agent: agent, country, path: url.pathname },
-          }),
-        }),
-      );
+      track(env, ctx, request, "hit");
+    } else if (!agent.includes("Mozilla") && (/\.json$/.test(url.pathname) || url.pathname.startsWith("/.well-known/"))) {
+      // Browsers (the homepage fetches /api/domains.json) identify as Mozilla;
+      // what's left is curl, scripts, and agents pulling the data files.
+      track(env, ctx, request, "data_fetch");
     }
 
     return await env.ASSETS.fetch(request);

--- a/worker/surface-page.ts
+++ b/worker/surface-page.ts
@@ -10,7 +10,7 @@
  * Chrome (tokens, nav, footer, atoms) comes from the shared src/lib/chrome.ts —
  * the SAME source Base.astro uses — so the static and SSR'd pages never drift.
  */
-import { GLOBAL_CSS, FONT_HEAD, navHtml, footerHtml, FOOTER_JS } from "../src/lib/chrome.ts";
+import { GLOBAL_CSS, FONT_HEAD, navHtml, footerHtml, FOOTER_JS, ANALYTICS_JS } from "../src/lib/chrome.ts";
 
 // Loose shapes (the value is parsed KV JSON; the schema is the source of truth).
 interface Mechanics {
@@ -219,6 +219,7 @@ export function renderSurfacePage(domain: string, surface: Surface, creds: Recor
 <meta name="description" content="${esc(`${surface.name} on ${domain}: a ${STYPE[surface.type] ?? surface.type} surface and how to authenticate.`)}">
 <link rel="icon" href="/favicon.ico" sizes="any"><link rel="icon" type="image/svg+xml" href="/favicon.svg">
 ${FONT_HEAD}
+<script>${ANALYTICS_JS}</script>
 <style>${GLOBAL_CSS}${SURFACE_CSS}</style></head><body>
 <div class="frame-guides"></div>
 ${navHtml(stars)}


### PR DESCRIPTION
## Why

Prepping for launch: browser traffic was completely invisible — the worker only counted `hit` events for executor user-agents. No pageviews, no web vitals, no funnel on the discovery CTA.

## What

**Client-side** (new)
- posthog-js snippet in the shared chrome (`ANALYTICS_JS` in `chrome.ts`), emitted by both `Base.astro` (all static pages) and `worker/surface-page.ts` (worker-SSR'd surface pages) — same no-drift pattern as `FOOTER_JS`.
- Points at a **first-party proxy**: the worker routes `/_i/static/*` → PostHog assets and `/_i/*` → ingestion, so ad blockers don't eat events. Client IP passes through via `x-forwarded-for` for geo.
- Skips init on localhost so dev sessions stay out of the data.
- `map_surface_clicked` captured on the discovery CTA (the site's key conversion).

**Server-side** (broadened — these callers never run JS)
- `mcp_request` — MCP clients hitting `/mcp`
- `api_request` — `/openapi.json`, `/api/{domain}/detect|discover`
- `discovery_run` — SSE discovery runs, with a `cached` flag
- `data_fetch` — non-browser callers pulling `.json` / `.well-known` files
- `hit` — unchanged (executor agents), existing dashboards keep working

**Ops** (already done, no action needed)
- New dedicated PostHog project **integrations.sh** (id 494034) in the Useful Software org, with web vitals autocapture + session replay enabled. Events were previously landing in the shared Production project.
- Production `POSTHOG_KEY` secret updated to the new project's token.

## Verified

- `bun run build` green; snippet present in built static + SSR HTML.
- Local `wrangler dev`: full posthog-js boot through the proxy (config, flags, surveys, event captures — all 200), and `data_fetch`/`api_request`/`proxy_smoke_test` events confirmed landing in the new project via HogQL.