### PR TITLE
Analytics: client PostHog via first-party proxy + server-side agent/API events

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,6 +1,6 @@
 ---
 import { stars } from "~/lib/github.ts";
-import { GLOBAL_CSS, FONT_HEAD, navHtml, footerHtml, FOOTER_JS } from "~/lib/chrome.ts";
+import { GLOBAL_CSS, FONT_HEAD, navHtml, footerHtml, FOOTER_JS, ANALYTICS_JS } from "~/lib/chrome.ts";
 
 interface Props {
   title: string;
@@ -46,5 +46,6 @@ const canonical = path ? new URL(path, Astro.site).href : undefined;
     </main>
     <Fragment set:html={footerHtml()} />
     <script is:inline set:html={FOOTER_JS} />
+    <script is:inline set:html={ANALYTICS_JS} />
   </body>
 </html>

--- a/src/lib/chrome.ts
+++ b/src/lib/chrome.ts
@@ -62,6 +62,23 @@ export const footerHtml = (): string =>
  * top and within ~one footer-height of the page bottom, so a long infinite-scroll
  * list still ends on a visible footer.
  */
+/**
+ * PostHog project token for the "integrations.sh" project (Useful Software org).
+ * phc_ tokens are public/write-only by design — safe to ship in page HTML.
+ */
+export const POSTHOG_TOKEN = "phc_kXqfUatEhy6uJvEZupSFx3yMPJVkr3nFBKmatLDLm2yj";
+
+/**
+ * Client analytics — the official posthog-js loader, pointed at the same-origin
+ * `/_i/` reverse proxy (worker/index.ts) so events survive adblockers and no
+ * third-party domain appears in CSP. Skips localhost so dev sessions don't
+ * pollute the project. Inline like FOOTER_JS: set:html-injected scripts don't
+ * run, so each consumer emits it as a real <script>.
+ */
+export const ANALYTICS_JS = `(function(){if(/^(localhost|127\\.0\\.0\\.1|\\[::1\\])$/.test(location.hostname))return;
+!function(t,e){var o,n,p,r;e.__SV||(window.posthog&&window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+posthog.init("${POSTHOG_TOKEN}",{api_host:location.origin+"/_i",ui_host:"https://us.posthog.com",defaults:"2026-05-30"});})();`;
+
 export const FOOTER_JS = `(function(){var f=document.getElementById("sfooter");if(!f)return;var bar=f.querySelector(".sf-bar"),lastY=window.scrollY,open=false;function set(v){open=v;f.classList.toggle("sf-open",v);bar.setAttribute("aria-expanded",String(v));}bar.addEventListener("click",function(){set(!open);});bar.addEventListener("keydown",function(e){if(e.key==="Enter"||e.key===" "){e.preventDefault();set(!open);}});function update(){var y=window.scrollY,d=document.documentElement,atEdge=(y<=8)||((y+window.innerHeight)>=(d.scrollHeight-96));if(!atEdge&&y>lastY&&y>120){f.classList.add("sf-hidden");if(open)set(false);}else if(atEdge||y<lastY){f.classList.remove("sf-hidden");}lastY=y;}window.addEventListener("scroll",update,{passive:true});update();})();`;
 
 /** The global stylesheet shared by every page (static + SSR'd). */

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -110,6 +110,38 @@ const json = (body: unknown, status = 200, headers: Record<string, string> = {})
     headers: { "content-type": "application/json; charset=utf-8", "access-control-allow-origin": "*", ...headers },
   });
 
+const POSTHOG_INGEST = "us.i.posthog.com";
+const POSTHOG_ASSETS = "us-assets.i.posthog.com";
+
+/**
+ * Server-side PostHog event. Covers the callers that never execute page JS —
+ * agents and API/MCP clients — so their traffic still lands in the project.
+ * IP as distinct_id with person profiles off: counts without identity.
+ */
+const track = (env: Env, ctx: ExecutionContext, request: Request, event: string, props: Record<string, unknown> = {}): void => {
+  if (!env.POSTHOG_KEY) return;
+  const url = new URL(request.url);
+  ctx.waitUntil(
+    fetch(`https://${POSTHOG_INGEST}/i/v0/e/`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        api_key: env.POSTHOG_KEY,
+        event,
+        distinct_id: request.headers.get("cf-connecting-ip") || "unknown",
+        properties: {
+          $process_person_profile: false,
+          path: url.pathname,
+          method: request.method,
+          user_agent: request.headers.get("user-agent") || "unknown",
+          country: request.headers.get("cf-ipcountry") || "unknown",
+          ...props,
+        },
+      }),
+    }).catch(() => {}),
+  );
+};
+
 export default {
   async fetch(
     request: Request,
@@ -119,15 +151,37 @@ export default {
     const url = new URL(request.url);
     wireAi(env);
 
+    // PostHog reverse proxy — the client snippet (chrome.ts ANALYTICS_JS) points
+    // here so events stay same-origin (adblock-resilient, no third-party CSP).
+    // /_i/static/* serves the SDK from the assets host; everything else is
+    // ingestion. Forward the client IP so geo/person data isn't the edge PoP.
+    if (url.pathname.startsWith("/_i/")) {
+      const rest = url.pathname.slice("/_i".length);
+      const upstreamHost = rest.startsWith("/static/") ? POSTHOG_ASSETS : POSTHOG_INGEST;
+      const upstream = new URL(`https://${upstreamHost}${rest}${url.search}`);
+      const headers = new Headers(request.headers);
+      headers.set("host", upstreamHost);
+      const ip = request.headers.get("cf-connecting-ip");
+      if (ip) headers.set("x-forwarded-for", ip);
+      return fetch(upstream.toString(), {
+        method: request.method,
+        headers,
+        body: request.body,
+        redirect: "follow",
+      });
+    }
+
     // MCP server — point Claude/Cursor at /mcp. Routed through a single Durable
     // Object so the session map persists across stateless Worker requests.
     if (url.pathname === "/mcp") {
+      track(env, ctx, request, "mcp_request");
       return env.MCP.get(env.MCP.idFromName("mcp")).fetch(request);
     }
 
     // Self-describe via the same discovery format the catalog indexes: point at
     // our own OpenAPI + MCP endpoint.
     if (url.pathname === "/.well-known/api-catalog") {
+      track(env, ctx, request, "data_fetch");
       return json(
         {
           linkset: [{
@@ -162,6 +216,7 @@ export default {
     const streamMatch = /^\/api\/([^/]+)\/discover\/stream\/?$/.exec(url.pathname);
     if (streamMatch) {
       const domain = decodeURIComponent(streamMatch[1]);
+      track(env, ctx, request, "discover_stream", { domain });
       const cache = (caches as unknown as { default: Cache }).default;
       const keyUrl = new URL(url.origin + `/api/${encodeURIComponent(domain)}/discover`);
       keyUrl.searchParams.set("__cv", CACHE_VERSION);
@@ -219,6 +274,7 @@ export default {
     // Dynamic API (the Effect HttpApi) — detect, discover + the OpenAPI doc.
     // Other /api/* paths (e.g. the static /api/domains.json) fall through to assets.
     if (url.pathname === "/openapi.json" || /^\/api\/[^/]+\/(?:detect|discover)\/?$/.test(url.pathname)) {
+      track(env, ctx, request, "api_request");
       const cache = (caches as unknown as { default: Cache }).default;
       // Version the cache key so a deploy that bumps CACHE_VERSION orphans stale
       // entries (the Cache API otherwise survives deploys).
@@ -273,23 +329,15 @@ export default {
       }
     }
 
-    // Analytics: count executor-agent hits.
-    const ip = request.headers.get("cf-connecting-ip") || "unknown";
-    const country = request.headers.get("cf-ipcountry") || "unknown";
+    // Analytics for non-page traffic. `hit` = executor agents (any path, the
+    // pre-launch event name — keep it so history stays one series). `data_fetch`
+    // = anything pulling the machine-readable registry (api.json, /disc/*,
+    // .well-known/*) — the agent-consumption signal page JS can't see.
     const agent = request.headers.get("user-agent") || "unknown";
     if (agent.includes("executor")) {
-      ctx.waitUntil(
-        fetch("https://us.i.posthog.com/i/v0/e/", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            api_key: env.POSTHOG_KEY,
-            event: "hit",
-            distinct_id: ip,
-            properties: { $process_person_profile: false, user_agent: agent, country, path: url.pathname },
-          }),
-        }),
-      );
+      track(env, ctx, request, "hit");
+    } else if (url.pathname === "/api.json" || url.pathname.startsWith("/disc/") || url.pathname.startsWith("/.well-known/")) {
+      track(env, ctx, request, "data_fetch");
     }
 
     return await env.ASSETS.fetch(request);

--- a/worker/surface-page.ts
+++ b/worker/surface-page.ts
@@ -10,7 +10,7 @@
  * Chrome (tokens, nav, footer, atoms) comes from the shared src/lib/chrome.ts —
  * the SAME source Base.astro uses — so the static and SSR'd pages never drift.
  */
-import { GLOBAL_CSS, FONT_HEAD, navHtml, footerHtml, FOOTER_JS } from "../src/lib/chrome.ts";
+import { GLOBAL_CSS, FONT_HEAD, navHtml, footerHtml, FOOTER_JS, ANALYTICS_JS } from "../src/lib/chrome.ts";
 
 // Loose shapes (the value is parsed KV JSON; the schema is the source of truth).
 interface Mechanics {
@@ -235,5 +235,6 @@ ${detailsHtml(surface)}
 </div></main>
 ${footerHtml()}
 <script>${FOOTER_JS}</script>
+<script>${ANALYTICS_JS}</script>
 </body></html>`;
 }


### PR DESCRIPTION
Prepping for launch — the site previously only counted executor-UA hits server-side; page traffic was invisible.

## What
- **Client**: official posthog-js loader in the shared chrome (`Base.astro` + the worker-SSR'd surface page — both consume `chrome.ts`, so no drift). `api_host` points at a same-origin `/_i/` reverse proxy so events survive adblockers. Skips localhost so dev sessions don't pollute the data.
- **Worker proxy**: `/_i/static/*` → PostHog assets host (SDK), everything else under `/_i/` → ingestion, forwarding `cf-connecting-ip` for correct geo.
- **Server-side events** for callers that never run page JS: `mcp_request` (/mcp), `api_request` (openapi.json, detect/discover), `discover_stream`, `data_fetch` (api.json, /disc/*, /.well-known/*). The pre-existing executor-UA `hit` series is unchanged.
- Events land in a new dedicated **integrations.sh** PostHog project (Useful Software org, id 494041) with session replay, web vitals, and heatmaps enabled. The `POSTHOG_KEY` worker secret has already been rotated to the new project token.

## Verified
- `bun run build` — snippet present in all 1,530 static pages
- `wrangler dev` smoke: `/_i/static/array.js` 200 (69.8kB js), proxied event POST → `{"status":"Ok"}`, and `api_request`/`data_fetch`/`hit` confirmed landing in project 494041 via HogQL