### PR TITLE
Show the Details section first on surface pages

### DIFF
--- a/src/pages/[domain]/[surface].astro
+++ b/src/pages/[domain]/[surface].astro
@@ -159,6 +159,32 @@ Astro.response.headers.set("cache-control", "public, max-age=60");
       </div>
     </header>
 
+    {detailRows.length > 0 && (
+      <section>
+        <div class="sec-header">
+          <span class="sec-label">Details</span>
+          {fromApisGuru && (
+            <span class="sec-note">
+              Spec supplied by <a href="https://apis.guru" target="_blank" rel="noopener noreferrer">APIs.guru</a>
+            </span>
+          )}
+        </div>
+        <dl class="kv">
+          {detailRows.map((r) => (
+            <>
+              <dt>{r.label}</dt>
+              <dd>
+                {r.kind === "code" && <code>{r.value}</code>}
+                {r.kind === "link" && (
+                  <a href={r.value} target="_blank" rel="noopener noreferrer">{r.linkLabel ?? r.value}</a>
+                )}
+                {r.kind === "text" && r.value}
+              </dd>
+            </>
+          ))}
+        </dl>
+      </section>
+    )}
     <section>
       <div class="sec-header"><span class="sec-label">Authentication</span></div>
       {surface.auth.status === "unknown" && <p class="muted">Authentication not yet determined.</p>}
@@ -212,33 +238,6 @@ Astro.response.headers.set("cache-control", "public, max-age=60");
             )}
           </div>
         ))}
-      </section>
-    )}
-
-    {detailRows.length > 0 && (
-      <section>
-        <div class="sec-header">
-          <span class="sec-label">Details</span>
-          {fromApisGuru && (
-            <span class="sec-note">
-              Spec supplied by <a href="https://apis.guru" target="_blank" rel="noopener noreferrer">APIs.guru</a>
-            </span>
-          )}
-        </div>
-        <dl class="kv">
-          {detailRows.map((r) => (
-            <>
-              <dt>{r.label}</dt>
-              <dd>
-                {r.kind === "code" && <code>{r.value}</code>}
-                {r.kind === "link" && (
-                  <a href={r.value} target="_blank" rel="noopener noreferrer">{r.linkLabel ?? r.value}</a>
-                )}
-                {r.kind === "text" && r.value}
-              </dd>
-            </>
-          ))}
-        </dl>
       </section>
     )}
   </div>


### PR DESCRIPTION
Moves the **Details** card (endpoint, transport, spec/command, docs) to the top of the surface detail page, above Connect / Authentication / Credentials.

Applies to all surface types (the template is shared and overwhelmingly MCP).

Verified against `wrangler dev` on an MCP surface (superhuman.com/superhuman-mail): rendered order is now Details → Connect → Authentication. `bun run build` passes.