### PR TITLE
Full-row click target on the homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -241,7 +241,8 @@ const mono = (d: string) => (d[0] || "?").toUpperCase();
   .kinds button span { opacity: 0.5; margin-left: 4px; }
 
   table.rows { width: 100%; border-collapse: collapse; margin-top: 18px; }
-  :global(table.rows tbody tr) { border-bottom: 1px solid var(--gray-100); }
+  :global(table.rows tbody tr) { position: relative; cursor: pointer; border-bottom: 1px solid var(--gray-100); }
+  :global(table.rows tbody tr:hover) { background: var(--gray-25); }
   :global(table.rows td) { padding: 13px 20px 13px 0; vertical-align: middle; }
   :global(.c-icon) { width: 30px; padding-right: 12px; }
   :global(.c-fav), :global(.c-icon .ph) {
@@ -254,10 +255,14 @@ const mono = (d: string) => (d[0] || "?").toUpperCase();
   }
   :global(.c-name) { white-space: nowrap; }
   :global(.c-name a) { font-weight: 500; font-size: 14.5px; text-decoration: none; }
+  /* Stretch the row's name link over the whole <tr> so the entire row is the hit target. */
+  :global(.c-name a::after) { content: ""; position: absolute; inset: 0; }
   :global(table.rows tr:hover .c-name a) { text-decoration: underline; text-underline-offset: 3px; }
 
   :global(.c-chips) { text-align: right; white-space: nowrap; padding-right: 0 !important; }
   :global(.c-chips .chip) {
+    /* Raised above the stretched name link so the format chips stay independently clickable. */
+    position: relative; z-index: 1;
     display: inline-flex; align-items: center; gap: 5px;
     font-family: var(--font-mono); font-size: 12px;
     color: var(--gray-500);


### PR DESCRIPTION
Makes the entire result row on the homepage the click target for the integration, instead of just the icon + domain name.

- Stretch the `.c-name` domain link across the whole `<tr>` with an inset `::after` (the `<tr>` becomes the positioning context).
- Raise the format chips (MCP/API/CLI) above the stretched link with `z-index` so they stay independently clickable and keep deep-linking to `/domain/#format`.
- Add a subtle row-hover fill and pointer cursor as the affordance.

Pure CSS; covers both the server-rendered rows and the client-side search results since they share the same markup.