### PR TITLE
Fix full-row tap target on iOS Safari (+ domain-page rows)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -193,6 +193,26 @@ const mono = (d: string) => (d[0] || "?").toUpperCase();
   document.addEventListener("keydown", (e) => {
     if (e.key === "/" && document.activeElement !== q) { e.preventDefault(); q.focus(); }
   });
+
+  // Full-row tap target. The name and format chips are real links; a tap
+  // anywhere else on a row delegates to that row's name link. Done in JS, not a
+  // CSS stretched-link ::after, because position:relative on a <tr> is NOT a
+  // containing block in iOS Safari — the overlay escaped its row and every tap
+  // landed on the last row (all routed to one domain). This has no layout
+  // dependency, so that failure mode can't recur.
+  const rowNav = (e: MouseEvent) => {
+    const t = e.target as HTMLElement;
+    if (t.closest("a, button")) return; // real links/buttons handle themselves
+    const link = t.closest("tr")?.querySelector<HTMLAnchorElement>(".c-name a");
+    const href = link?.getAttribute("href");
+    if (!href) return;
+    if (e.metaKey || e.ctrlKey || e.button === 1) window.open(href, "_blank", "noopener");
+    else window.location.href = href;
+  };
+  for (const el of [tbody, typeahead]) {
+    el.addEventListener("click", rowNav);
+    el.addEventListener("auxclick", rowNav); // middle-click → new tab
+  }
 </script>
 
 <style>
@@ -242,7 +262,7 @@ const mono = (d: string) => (d[0] || "?").toUpperCase();
   .kinds button span { opacity: 0.5; margin-left: 4px; }
 
   table.rows { width: 100%; border-collapse: collapse; margin-top: 18px; }
-  :global(table.rows tbody tr) { position: relative; cursor: pointer; border-bottom: 1px solid var(--gray-100); }
+  :global(table.rows tbody tr) { cursor: pointer; border-bottom: 1px solid var(--gray-100); }
   :global(table.rows tbody tr:hover) { background: var(--gray-25); }
   :global(table.rows td) { padding: 13px 20px 13px 0; vertical-align: middle; }
   :global(.c-icon) { width: 30px; padding-right: 12px; }
@@ -256,14 +276,10 @@ const mono = (d: string) => (d[0] || "?").toUpperCase();
   }
   :global(.c-name) { white-space: nowrap; }
   :global(.c-name a) { font-weight: 500; font-size: 14.5px; text-decoration: none; }
-  /* Stretch the row's name link over the whole <tr> so the entire row is the hit target. */
-  :global(.c-name a::after) { content: ""; position: absolute; inset: 0; }
   :global(table.rows tr:hover .c-name a) { text-decoration: underline; text-underline-offset: 3px; }
 
   :global(.c-chips) { text-align: right; white-space: nowrap; padding-right: 0 !important; }
   :global(.c-chips .chip) {
-    /* Raised above the stretched name link so the format chips stay independently clickable. */
-    position: relative; z-index: 1;
     display: inline-flex; align-items: center; gap: 5px;
     font-family: var(--font-mono); font-size: 12px;
     color: var(--gray-500);

--- a/src/styles/discovery.css
+++ b/src/styles/discovery.css
@@ -20,9 +20,13 @@
 .disc-regenerate { font-family: var(--font-mono); font-size: 11.5px; color: var(--gray-700); }
 .disc-sec { margin-top: 40px; max-width: 760px; scroll-margin-top: 24px; }
 .disc-list { list-style: none; padding: 0; margin: 0; }
-.disc-entry { border-bottom: 1px solid var(--gray-100); padding: 13px 0; }
+.disc-entry { position: relative; border-bottom: 1px solid var(--gray-100); padding: 13px 0; }
+.disc-entry:has(a.disc-ename) { cursor: pointer; }
+.disc-entry:has(a.disc-ename):hover { background: var(--gray-25); }
 .disc-entry-head { display: flex; align-items: baseline; gap: 11px; }
 .disc-ename { font-weight: 500; font-size: 14.5px; color: var(--gray-1000); text-decoration: none; }
+/* Stretch the name link over the whole entry so the entire row is the hit target. */
+a.disc-ename::after { content: ""; position: absolute; inset: 0; }
 a.disc-ename:hover { text-decoration: underline; text-underline-offset: 3px; }
 .disc-emeta { margin-left: auto; font-family: var(--font-mono); font-size: 12px; color: var(--gray-400); white-space: nowrap; }
 .disc-prov { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.03em; text-transform: uppercase; padding: 1px 5px; border-radius: 4px; cursor: default; }
@@ -33,13 +37,18 @@ a.disc-ename:hover { text-decoration: underline; text-underline-offset: 3px; }
 .conv-summary { cursor: pointer; width: max-content; max-width: 100%; }
 .conv-summary-text { text-transform: none; letter-spacing: 0; }
 .conv-list { list-style: none; padding: 0; margin: 10px 0 0; }
-.conv-row { display: grid; grid-template-columns: minmax(136px, 0.32fr) 18px minmax(0, 1fr); gap: 10px; align-items: baseline; padding: 8px 0; border-bottom: 1px solid var(--gray-100); }
+.conv-row { position: relative; display: grid; grid-template-columns: minmax(136px, 0.32fr) 18px minmax(0, 1fr); gap: 10px; align-items: baseline; padding: 8px 0; border-bottom: 1px solid var(--gray-100); }
+.conv-row:has(a.conv-name) { cursor: pointer; }
+.conv-row:has(a.conv-name):hover { background: var(--gray-25); }
 .conv-name { font-family: var(--font-mono); font-size: 12px; color: var(--gray-700); text-decoration: none; word-break: break-word; }
+/* Stretch the spec link over the whole row; the detail links below are raised back above it. */
+a.conv-name::after { content: ""; position: absolute; inset: 0; }
 a.conv-name:hover { text-decoration: underline; text-underline-offset: 2px; }
 .conv-status { font-family: var(--font-mono); font-size: 12px; color: var(--gray-400); text-align: center; }
 .conv-status-found { color: var(--gray-1000); }
 .conv-status-missing, .conv-status-unprobed { color: var(--gray-400); }
 .conv-detail { min-width: 0; font-size: 12px; color: var(--gray-500); line-height: 1.55; overflow-wrap: anywhere; }
+.conv-detail a, .conv-detail button { position: relative; z-index: 1; }
 .conv-path { font-family: var(--font-mono); color: var(--gray-400); background: transparent; padding: 0; border-radius: 0; }
 .conv-link { color: var(--gray-1000); text-decoration: underline; text-underline-offset: 2px; }
 .conv-link:hover { color: var(--gray-500); }


### PR DESCRIPTION
## Bug
A user reported (Discord) that on iOS Safari, every tap on the homepage list routed to the same domain (`zoho.dev`), regardless of where they tapped.

## Cause
The recent full-row click target used a CSS stretched link: `.c-name a::after { position:absolute; inset:0 }` relying on `position: relative` on the `<tr>` as its containing block. **iOS Safari (WebKit) does not honor `position: relative` on table rows as a containing block**, so each row's overlay escaped to the viewport. They stacked, and the last row in the DOM (a `zoho.*` domain) ended up on top, capturing every tap. Chrome/Firefox honor it, so desktop looked fine.

## Fix
- **Homepage:** drop the `::after` overlay; make the whole row a tap target via **JS delegation** on the row container. The name and format chips stay real `<a>` links; a tap anywhere else on the row opens that row's name link (cmd/ctrl/middle-click → new tab). No layout dependency, so the escaped-overlay failure is structurally impossible.
- **Domain pages:** apply the same full-row target to the surface-entry and convention rows. These are `<li>`/grid boxes, where `position: relative` is a spec-guaranteed containing block in every browser (only table-internal boxes have the Safari quirk), so the CSS stretched link is safe there.

## Verification
Playwright **WebKit** (iPhone 13 viewport): homepage `::after` overlay is gone; tapping each row body (over the icon, off the name link) routes to that row's own domain (6/6 distinct, no collapse); format chips still deep-link correctly; domain-page rows resolve per-row. Note: Playwright's WebKit build did not itself reproduce the original overlay-escape (its layout engine differs from real iOS Safari here), which is why the fix targets the documented root cause and removes the fragile construct rather than relying on runtime behavior.