### PR TITLE
Fix mobile horizontal overflow on the homepage domain table

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -281,4 +281,21 @@ const mono = (d: string) => (d[0] || "?").toUpperCase();
 
   .status { color: var(--gray-400); font-family: var(--font-mono); font-size: 12px; margin: 16px 0 0; }
   #sentinel { height: 1px; }
+
+  /* Mobile: the desktop rows are single-line (name + chips both nowrap), which
+     forces the table wider than a phone screen. Break each row down to a flex
+     line so the name keeps priority (stays whole) and the format chips wrap
+     beneath themselves — the chips have the larger content width, so they give
+     up space first. The table shrinks to the viewport instead of scrolling. */
+  @media (max-width: 640px) {
+    :global(table.rows), :global(table.rows tbody), :global(table.rows tfoot) { display: block; }
+    :global(table.rows tr) { display: flex; align-items: center; gap: 12px; padding: 11px 0; }
+    :global(table.rows td) { display: block; padding: 0; }
+    :global(.c-icon) { flex: none; width: auto; }
+    :global(.c-name) { flex: 1 1 auto; min-width: 0; white-space: normal; overflow-wrap: anywhere; }
+    /* Cap the chips so 3–4 formats wrap to a second line rather than crowding
+       out the domain name — keeps the name on one line in the common case. */
+    :global(.c-chips) { flex: 0 1 auto; max-width: 46%; white-space: normal; }
+    :global(.c-chips .chip) { margin: 3px 0 3px 6px; }
+  }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -29,6 +29,8 @@ a { color: inherit; }
 .frame-guides::after { right: calc(50% - var(--container) / 2); }
 @media (max-width: 1140px) { .frame-guides { display: none; } }
 .container { max-width: var(--container); margin: 0 auto; padding: 0 40px; position: relative; z-index: 1; }
+/* On phones the 40px gutter eats a fifth of a 375px viewport — pull it in. */
+@media (max-width: 640px) { .container { padding: 0 20px; } }
 
 nav.site { border-bottom: 1px solid var(--gray-100); background: var(--white); position: relative; z-index: 2; }
 nav.site .container { height: 64px; display: flex; align-items: center; gap: 32px; }


### PR DESCRIPTION
## Problem

On phones the homepage domain table couldn't shrink below ~415px: both the domain name (`.c-name`) and the format chips (`.c-chips`) were `white-space: nowrap`, so a 375px viewport got ~80px of horizontal scroll and the MCP/API badges were pushed off the right edge.

## Fix (CSS-only, mobile-only — all inside `@media (max-width: 640px)`, desktop untouched)

- **index.astro** — on mobile the rows become flex lines: the name keeps priority (stays on one line) and the format chips wrap to a second line for 3–4 format domains. Chips capped at 46% so they can't crowd out the name.
- **global.css** — container gutter 40px → 20px on phones (40px ate a fifth of a 375px viewport). Benefits every page.

## Verified in Chromium at mobile viewports

| Case | Result |
|---|---|
| Default list @ 375px & 320px | 0px overflow, icons + chips intact |
| `agilitycms.com` (4 formats) | name stays 1 line, chips wrap 2×2 |
| 49-char domain | wraps cleanly at hyphen/dot boundaries, 0 overflow |
| `/slack.com/` domain page | 0px overflow |

`bun run build` passes.