### PR TITLE
Stop iOS Safari zooming on search focus

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -228,9 +228,13 @@ const mono = (d: string) => (d[0] || "?").toUpperCase();
     border: 1px solid var(--gray-200);
     border-radius: 8px;
     color: var(--gray-1000);
-    font: inherit; font-size: 14px;
+    /* ≥16px on touch widths or iOS Safari zooms the page on focus */
+    font: inherit; font-size: 16px;
     outline: none;
     transition: border-color 0.12s;
+  }
+  @media (min-width: 641px) {
+    #q { font-size: 14px; }
   }
   #q:focus { border-color: var(--gray-400); }
   #q::placeholder { color: var(--gray-300); }


### PR DESCRIPTION
Multiple reports from the launch thread: on mobile, tapping the search input zooms the page in.

Cause: iOS Safari auto-zooms when a focused input's computed font-size is under 16px, and `#q` was hardcoded to 14px at every breakpoint.

Fix: 16px base font-size on the search input (mobile-first), with the previous 14px restored from 641px up via a media query — matching the site's existing breakpoint. Desktop rendering is unchanged.

Verified in a browser at 375px (16px computed) and 1280px (14px computed); `bun run build` passes.