### PR TITLE
Don't classify client SDKs as CLI surfaces

### DIFF
--- a/scripts/normalize.ts
+++ b/scripts/normalize.ts
@@ -9,6 +9,7 @@ import { getDomain as tldGetDomain } from "tldts";
 const getDomain = (url: string) => tldGetDomain(url, { allowPrivateDomains: true });
 import type { Integration, Feed, Kind, ExtractedTool } from "../src/lib/types.ts";
 import { faviconUrl, isJunkDomain } from "../src/lib/favicon.ts";
+import { isSdkNotCli } from "../src/lib/surface-classify.ts";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const SOURCES = join(ROOT, "sources");
@@ -411,6 +412,8 @@ function buildDiscovered(knownDomains: Set<string>): Integration[] {
     const surfaces = d.surfaces ?? [];
     const byKind = new Map<Kind, DiscoveredSurface>();
     for (const surface of surfaces) {
+      // A client SDK/library mis-typed as `cli` is not a CLI surface — skip it.
+      if (isSdkNotCli(surface)) continue;
       const kind = discoveredKind(surface.type);
       if (!byKind.has(kind)) byKind.set(kind, surface);
     }

--- a/src/lib/discover.ts
+++ b/src/lib/discover.ts
@@ -179,7 +179,7 @@ const AUTH_ENTRY_PROPS = {
 
 const SURFACE_PROPS = {
   name: { type: "string" },
-  type: { type: "string", description: "http (REST/OpenAPI) | graphql | mcp | cli" },
+  type: { type: "string", description: "http (REST/OpenAPI) | graphql | mcp | cli. `cli` is a genuine command-line EXECUTABLE the user runs in a shell — NOT a client SDK/library you import in code." },
   docs: { type: "string" },
   spec: { type: "string", description: "OpenAPI URL, or 'introspection'/SDL URL for graphql — a POINTER, never inline a spec" },
   specAlternates: { type: "array", items: { type: "string" }, description: "Additional machine-readable spec documents for the SAME API in other formats (e.g. the YAML twin of a JSON OpenAPI doc)." },
@@ -254,6 +254,7 @@ const SYSTEM =
   "- example.com/org hosts in docs are placeholders from spec `servers` blocks, never real endpoints — use the templated form or omit the url.\n" +
   "- Tenant-templated base URLs are valid locators — record them verbatim with placeholders ({account}.api.example.com, https://<your-instance>.example.com/api). An empty `url` because the host varies per tenant is wrong.\n" +
   "- Web dashboards/consoles and CI integrations (GitHub Actions, marketplace apps) are NOT surfaces — only programmatic interfaces a developer or agent calls: HTTP/GraphQL APIs, MCP connect endpoints, CLIs. When in doubt ask: could a script call this? If not, omit it.\n" +
+  "- A client SDK or library — an npm/pip/gem/etc. package you IMPORT in code (e.g. '<Product> JavaScript/TypeScript SDK', a Python client, an Android/iOS SDK) — is NOT a `cli` surface, and by itself is NOT a surface at all. It is a wrapper over an HTTP/GraphQL API: record THAT underlying API surface instead (its base URL / spec), attributed to the host the SDK actually calls. Reserve `cli` for a genuine command-line EXECUTABLE the user runs in a shell — a real binary with a `command` like `wrangler`, `gh`, `stripe`, `supabase` (a runtime like `python`/`node`/`npx` is NOT a command). If a service ships only an SDK/library and exposes no documented HTTP/GraphQL/MCP surface or standalone CLI, conclude it has no integration surface and finish with empty surfaces — do NOT file the SDK under `cli`.\n" +
   "- An mcp surface's `url` is the CONNECT ENDPOINT an MCP client would use (e.g. https://mcp.example.com/mcp), never a docs page about the server. If only a docs page exists, put it in `docs` and leave `url` unset.\n" +
   "- Write each credential's `setup` around the EASIEST acquisition path. When a CLI login acquires it (`mint login`, `wrangler login`), setup says 'run `x login`' and the binding is mechanics 'cli' with that command — do NOT walk through raw OAuth authorize/token/register endpoints anywhere in setup.\n" +
   "- When a CLI has an interactive `login` command AND the same credential can also be supplied via env var or a `--token`/`--key` flag, the `login` command is the PRIMARY path: write `setup` around 'run `x login`' and mention the env/flag token only as a non-interactive/CI fallback. NEVER lead with 'create a token in dashboard settings' when an interactive login exists — record both bindings (login as an acquisition command, env/flag as consumption) on the one credential.\n" +

--- a/src/lib/surface-classify.ts
+++ b/src/lib/surface-classify.ts
@@ -1,0 +1,29 @@
+// A client SDK / library is NOT a CLI. Before the discovery prompt was
+// tightened, the agent filed import-me packages (an npm/pip client, a
+// "<Product> JavaScript/TypeScript SDK") under `cli`, because that was the
+// closest of the four surface types (http | graphql | mcp | cli). This
+// predicate identifies those mis-typed surfaces so the display + catalog paths
+// can drop them from the CLI section.
+//
+// The check is deliberately NAME-driven. The `command` field is not a reliable
+// discriminator: the agent routinely emitted runtimes (`python`, `node`,
+// `npx`), the bare package name (`benchling`, `galileo`), or even code calls
+// (`Rutter.create`) as the "command" of an SDK. So we ignore `command` and give
+// the benefit of the doubt only when the name itself explicitly says CLI.
+
+const SDK_NAME =
+  /\bsdks?\b|\bclient librar(?:y|ies)\b|\b(?:npm|pypi|pip|gem|composer|nuget|maven|packagist)\s+package\b|\b(?:node(?:\.?js)?|javascript|typescript|python|ruby|php|java|kotlin|swift|go(?:lang)?|\.net|dotnet|rust|android|ios|react[-\s]?native)\s+(?:sdk|client|library|package)\b/i;
+
+// If the name itself calls it a CLI / command-line tool, keep it — it is either
+// a genuine command-line executable or a dual SDK+CLI where the CLI is real.
+const EXPLICIT_CLI = /\bclis?\b|command[-\s]?line/i;
+
+/** True when a `cli`-typed surface is really a client SDK/library, not a
+ *  command-line executable. Shared by the live render path (buildSections) and
+ *  the static catalog build (buildDiscovered) so both classify identically. */
+export function isSdkNotCli(surface: { type?: string; name?: string }): boolean {
+  if (surface.type !== "cli") return false;
+  const name = surface.name ?? "";
+  if (!SDK_NAME.test(name)) return false;
+  return !EXPLICIT_CLI.test(name);
+}

--- a/src/lib/surface-sections.ts
+++ b/src/lib/surface-sections.ts
@@ -1,5 +1,6 @@
 import { KIND_ORDER, SECTION_LABEL } from "./domain-labels.ts";
 import type { DiscoveryResult } from "./discovery-schema.ts";
+import { isSdkNotCli } from "./surface-classify.ts";
 import type { DiscoveryDoc, Surface } from "./surface-view.ts";
 
 export type DiscoverData = Partial<Pick<DiscoveryResult, "summary" | "description" | "discoveredAt">> & DiscoveryDoc & { detect?: unknown };
@@ -61,7 +62,8 @@ export function buildSections(data: DiscoverData | null, domain: string): Surfac
 
   for (const kind of KIND_ORDER) {
     const entries = surfaces
-      .map((surface, idx) => ({ surface, idx, kind: kindOf(surface.type) }))
+      // A client SDK/library mis-typed as `cli` is not a CLI surface — drop it.
+      .map((surface, idx) => ({ surface, idx, kind: isSdkNotCli(surface) ? null : kindOf(surface.type) }))
       .filter((item) => item.kind === kind)
       .map(({ surface, idx }) => ({
         key: `${surface.slug || surface.name}-${idx}`,


### PR DESCRIPTION
## Problem

integrations.sh reported client SDKs as CLIs. The discovery agent has only four surface types — `http | graphql | mcp | cli` — so a service that ships only a client SDK/library gets its SDK filed under `cli`. e.g. **computesdk.com** rendered a "CLI" section for its *JavaScript/TypeScript SDK*, while its own summary said it "found no documented HTTP/REST, GraphQL, MCP, or standalone CLI surface."

Not a one-off: ~6% of the catalog's `cli` surfaces (80+ of 1,313 across batch results + `discovered.json`) were actually SDKs — SecureLend, Galileo, Rutter, Benchling, OpenRouter, Retell, …

## Fix

**Tighten the definition (going forward)** — `src/lib/discover.ts`
- The discovery prompt now states a client SDK/library is **not** a `cli` surface (and usually not a surface at all): record the underlying HTTP/GraphQL API it wraps, or conclude there is no surface. `cli` is reserved for a genuine shell executable (a runtime like `python`/`node`/`npx` is not a command). Reinforced in the `record_surface` `type` schema.

**Reclassify existing data (render-time)** — new `src/lib/surface-classify.ts` → `isSdkNotCli()`
- Applied at **both** chokepoints: `buildSections` (live/SSR) and `buildDiscovered` (static catalog).
- **Name-driven by design:** the `command` field is unreliable — the agent fabricated runtimes (`python`, `node`, `npx`), bare package names, even code calls (`Rutter.create`). Names that explicitly say "CLI" are kept, so genuine/dual CLIs (Fugle, Canva, Transloadit) survive.
- Because the live filter runs at render time, the KV-cached computesdk.com card drops its CLI on the next render — no cache purge or re-discovery needed.

## Verification

- `bun run build` passes.
- Predicate over real data: drops ComputeSDK / SecureLend / Galileo / Rutter / Benchling / OpenRouter / Retell / ntropy / Atomic Transact iOS; keeps Wrangler / gh / Stripe / Supabase / Vercel and dual "CLI/SDK" names. Non-`cli` types untouched.
- Static catalog: 20 of 513 `cli` surfaces dropped as SDKs; genuine CLIs retained.

## Known conservative gap

A few names carry both "SDK" and "CLI" (e.g. "SignalWire Agents SDK CLI tools") and are intentionally **kept** to avoid dropping real CLIs.