### PR TITLE
Drop SDK-as-CLI surfaces from detail pages, JSON-LD, and discovery API

### DIFF
--- a/src/components/DomainPage.astro
+++ b/src/components/DomainPage.astro
@@ -12,6 +12,7 @@ import Surfaces from "~/components/Surfaces.tsx";
 import { faviconUrl } from "~/lib/favicon.ts";
 import { KIND_ORDER, SHORT_LABEL } from "~/lib/domain-labels.ts";
 import { kindOf, type DiscoverData } from "~/lib/surface-sections.ts";
+import { isSdkNotCli } from "~/lib/surface-classify.ts";
 import type { Kind } from "~/lib/types.ts";
 import "~/styles/discovery.css";
 
@@ -21,7 +22,15 @@ interface Props {
   initialData?: DiscoverData | null;
 }
 
-const { domain, initialData = null } = Astro.props;
+const { domain, initialData: rawInitialData = null } = Astro.props;
+
+// A client SDK/library mis-typed as `cli` is not a surface — strip it once here
+// so the header counts, the sections, the JSON-LD ItemList, and the hydrated
+// island all agree. Covers both the prerendered and the SSR domain page, which
+// both render this component.
+const initialData = rawInitialData?.surfaces
+  ? { ...rawInitialData, surfaces: rawInitialData.surfaces.filter((s) => !isSdkNotCli(s)) }
+  : rawInitialData;
 
 // Header line: counts and kinds from the discovery document only.
 const surfaces = initialData?.surfaces ?? [];

--- a/src/pages/[domain]/[surface].astro
+++ b/src/pages/[domain]/[surface].astro
@@ -12,6 +12,7 @@ import Base from "~/layouts/Base.astro";
 import Breadcrumb from "~/components/Breadcrumb.astro";
 import Setup from "~/components/surface/Setup.tsx";
 import { faviconFor, isJunkDomain } from "~/lib/favicon.ts";
+import { isSdkNotCli } from "~/lib/surface-classify.ts";
 import {
   SURFACE_TYPE_LABEL,
   cliLoginFor,
@@ -35,8 +36,10 @@ const slug = decodeURIComponent(Astro.params.surface ?? "");
 // plain 404 (Astro renders 404.astro for rewrites to a missing route).
 const looksLikeDomain = domain.includes(".");
 
-// Slugs are server-assigned identity (v3) — match directly.
-const find = (doc?: DiscoveryDoc | null) => (doc?.surfaces ?? []).find((s) => s.slug === slug);
+// Slugs are server-assigned identity (v3) — match directly. A client SDK/library
+// mis-typed as `cli` is not a surface, so its slug resolves to nothing → 404.
+const find = (doc?: DiscoveryDoc | null) =>
+  (doc?.surfaces ?? []).find((s) => s.slug === slug && !isSdkNotCli(s));
 
 let surface: Surface | undefined;
 let creds: Record<string, Credential> = {};

--- a/worker/discovery-doc.ts
+++ b/worker/discovery-doc.ts
@@ -1,5 +1,13 @@
 import type { Env } from "./env.ts";
 import type { DiscoverData } from "../src/lib/surface-sections.ts";
+import { isSdkNotCli } from "../src/lib/surface-classify.ts";
+
+/** Drop client SDKs/libraries mis-typed as `cli` — they are not a surface. This
+ * loader feeds the `/api/{domain}/discovery` JSON endpoint (the island's mount
+ * fetch) and the OG image, so filtering here keeps them consistent with the
+ * SSR'd pages. */
+const stripSdkSurfaces = (doc: DiscoverData): DiscoverData =>
+  doc.surfaces?.length ? { ...doc, surfaces: doc.surfaces.filter((s) => !isSdkNotCli(s)) } : doc;
 
 /** The domain page's render source: durable discovery result first, then the
  * prerendered baseline discovery JSON. */
@@ -9,13 +17,13 @@ export async function discoveryDoc(env: Env, origin: string, domain: string): Pr
     if (raw) {
       const stored = JSON.parse(raw) as { result?: DiscoverData; discoveredAt?: string };
       if (stored.result?.surfaces?.length) {
-        return { ...stored.result, discoveredAt: stored.result.discoveredAt ?? stored.discoveredAt };
+        return stripSdkSurfaces({ ...stored.result, discoveredAt: stored.result.discoveredAt ?? stored.discoveredAt });
       }
     }
     const res = await env.ASSETS.fetch(`${origin}/disc/${encodeURIComponent(domain)}.json`);
     if (res.ok) {
       const baseline = (await res.json()) as DiscoverData;
-      if (baseline.surfaces?.length) return baseline;
+      if (baseline.surfaces?.length) return stripSdkSurfaces(baseline);
     }
   } catch {
     /* unavailable or malformed discovery data */


### PR DESCRIPTION
Follow-up to #20. That PR filtered the CLI **section** on the domain page (`buildSections`), but three other render paths bypass it and still reported an SDK as a CLI — e.g. `/computesdk.com/computesdk-javascript-typescript-sdk/` rendered `ComputeSDK JavaScript/TypeScript SDK — CLI`, and the domain page's JSON-LD still listed it.

## Remaining leaks closed

Using the same shared `isSdkNotCli()`:

- **`DomainPage.astro`** — strips `initialData.surfaces` once, so the header counts, sections, `schema.org` `ItemList` JSON-LD, and the hydrated island all agree. Covers both the prerendered and SSR domain page (both render this component).
- **`[domain]/[surface].astro`** — excludes SDK slugs from the surface lookup, so a mis-typed SDK's detail page returns **404** instead of `— CLI`.
- **`worker/discovery-doc.ts`** — strips both the KV and baseline reads. This loader backs the `/api/{domain}/discovery` JSON (the island's on-mount fetch when there's no baked-in data) and the OG image.

## Effect on computesdk.com (already-cached KV, no re-discovery needed)

- Domain page: 0 surfaces, no CLI section, JSON-LD no longer lists the SDK.
- `/computesdk.com/computesdk-javascript-typescript-sdk/` → 404.
- `/api/computesdk.com/discovery` and the OG image → SDK surface gone.

`bun run build` passes.