### PR TITLE
Strip SDK-as-CLI surfaces from the stored-discovery API

### DIFF
--- a/worker/entry.ts
+++ b/worker/entry.ts
@@ -21,6 +21,7 @@ import { discoveryDoc } from "./discovery-doc.ts";
 import { setChat, setWebBackend, discoverWithProgress, preserveSlugs } from "./operations.ts";
 import { contextWeb, naiveWeb } from "../src/lib/contextdev.ts";
 import { isJunkDomain, registrableDomain } from "../src/lib/favicon.ts";
+import { isSdkNotCli } from "../src/lib/surface-classify.ts";
 import { renderOgPng, type OgFonts, type OgImageData } from "../src/lib/og.tsx";
 import type { Surface } from "../src/lib/surface-view.ts";
 import type { Credential } from "../src/lib/surface-view.ts";
@@ -262,6 +263,22 @@ function discoveryCounts(result: {
   };
 }
 
+/** Drop SDK-as-`cli` surfaces from a stored-discovery KV envelope's JSON string,
+ * so the /api/{domain}/discovery endpoint matches the rendered pages. Serves the
+ * value unchanged if it doesn't parse into the expected shape. */
+function stripSdkFromStored(raw: string): string {
+  try {
+    const envelope = JSON.parse(raw) as { result?: { surfaces?: Surface[] } };
+    if (envelope.result?.surfaces?.length) {
+      envelope.result.surfaces = envelope.result.surfaces.filter((s) => !isSdkNotCli(s));
+      return JSON.stringify(envelope);
+    }
+  } catch {
+    /* malformed — serve as-is */
+  }
+  return raw;
+}
+
 async function healthz(env: Env): Promise<Response> {
   const kv = await Promise.race([
     env.DISCOVERY.get("stripe.com"),
@@ -494,7 +511,10 @@ async function handleRequest(
     if (storedMatch) {
       const domain = decodeURIComponent(storedMatch[1]).trim().toLowerCase();
       const raw = await env.DISCOVERY.get(domain);
-      return new Response(raw ?? JSON.stringify({ stored: false }), {
+      // Strip client SDKs mis-typed as `cli` so this stored-discovery API agrees
+      // with what the pages render. Falls back to raw if the value doesn't parse.
+      const body = raw ? stripSdkFromStored(raw) : JSON.stringify({ stored: false });
+      return new Response(body, {
         status: raw ? 200 : 404,
         headers: { "content-type": "application/json; charset=utf-8", "access-control-allow-origin": "*", "cache-control": "public, max-age=60" },
       });


### PR DESCRIPTION
Third and final leak from the ComputeSDK report. `/api/{domain}/discovery` (the client island's on-mount fetch, and a public JSON endpoint) is served by its **own inline KV read** in `worker/entry.ts` — separate from `discoveryDoc()` — and returned the raw KV envelope. So it still advertised an SDK mis-typed as `cli` even after #20 (sections) and #21 (detail page, JSON-LD, OG/`surface` API).

Filters the stored envelope's `result.surfaces` with the shared `isSdkNotCli()` before responding; serves the value unchanged if it doesn't parse. Now the JSON API agrees with the rendered pages.

`bun run build` passes.