### PR TITLE
Neutral grayscale text selection

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -20,8 +20,9 @@ html { scrollbar-gutter: stable; }
 html, body { margin: 0; padding: 0; }
 body { background: var(--white); color: var(--gray-900); font: 400 15px/1.55 var(--font-sans); -webkit-font-smoothing: antialiased; min-height: 100vh; display: flex; flex-direction: column; }
 a { color: inherit; }
-::selection { background: #dbeafe; color: #0a0a0a; }
-@media (prefers-color-scheme: dark) { ::selection { background: #2e4a6e; color: #ededed; } }
+/* Neutral text selection — the design language holds color to a single role, so
+   selection uses the grayscale ramp (tokens flip with color-scheme) not blue. */
+::selection { background: var(--gray-200); color: var(--gray-1000); }
 
 .frame-guides { position: fixed; inset: 0; pointer-events: none; z-index: 0; }
 .frame-guides::before, .frame-guides::after { content: ""; position: absolute; top: 0; bottom: 0; width: 1px; background: var(--gray-100); }


### PR DESCRIPTION
Text selection was rendering blue (#dbeafe light / #2e4a6e dark), which clashes with the strict grayscale design language. Points `::selection` at the `--gray-200`/`--gray-1000` tokens (they already flip with color-scheme), so selecting text — e.g. a domain name on a domain page — reads on-brand in both modes. CSS-only; build is green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/UsefulSoftwareCo/codesmith/integrationsdotsh/pr/27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785651866&installation_id=144115332&pr_number=27&repository=UsefulSoftwareCo%2Fintegrationsdotsh&return_to=https%3A%2F%2Fgithub.com%2FUsefulSoftwareCo%2Fintegrationsdotsh%2Fpull%2F27&signature=02c712228069ec3590c95c655f0343ff7c1cb7a32ea86c8b57e1ae361f75e3ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->