### PR TITLE
Bleed the row hover band past the content edges

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -265,10 +265,14 @@ const mono = (d: string) => (d[0] || "?").toUpperCase();
   .kinds button.active { color: var(--gray-1000); border-bottom-color: var(--gray-1000); }
   .kinds button span { opacity: 0.5; margin-left: 4px; }
 
-  table.rows { width: 100%; border-collapse: collapse; margin-top: 18px; }
+  /* The hover band bleeds past the content edges — flush against the favicon
+     and end chip it reads cramped. The table pulls back by the same amount so
+     the content itself stays on the container grid. 0 on mobile (flex rows). */
+  table.rows { --row-bleed: 16px; width: calc(100% + 2 * var(--row-bleed)); border-collapse: collapse; margin: 18px calc(-1 * var(--row-bleed)) 0; }
   :global(table.rows tbody tr) { cursor: pointer; border-bottom: 1px solid var(--gray-100); }
   :global(table.rows tbody tr:hover) { background: var(--gray-25); }
   :global(table.rows td) { padding: 13px 20px 13px 0; vertical-align: middle; }
+  :global(table.rows td:first-child) { padding-left: var(--row-bleed); }
   :global(.c-icon) { width: 30px; padding-right: 12px; }
   :global(.c-fav), :global(.c-icon .ph) {
     width: 18px; height: 18px; border-radius: 4px; display: block; object-fit: contain;
@@ -282,7 +286,7 @@ const mono = (d: string) => (d[0] || "?").toUpperCase();
   :global(.c-name a) { font-weight: 500; font-size: 14.5px; text-decoration: none; }
   :global(table.rows tr:hover .c-name a) { text-decoration: underline; text-underline-offset: 3px; }
 
-  :global(.c-chips) { text-align: right; white-space: nowrap; padding-right: 0 !important; }
+  :global(.c-chips) { text-align: right; white-space: nowrap; padding-right: var(--row-bleed) !important; }
   :global(.c-chips .chip) {
     display: inline-flex; align-items: center; gap: 5px;
     font-family: var(--font-mono); font-size: 12px;
@@ -308,6 +312,7 @@ const mono = (d: string) => (d[0] || "?").toUpperCase();
      beneath themselves — the chips have the larger content width, so they give
      up space first. The table shrinks to the viewport instead of scrolling. */
   @media (max-width: 640px) {
+    table.rows { --row-bleed: 0px; }
     :global(table.rows), :global(table.rows tbody), :global(table.rows tfoot) { display: block; }
     :global(table.rows tr) { display: flex; align-items: center; gap: 12px; padding: 11px 0; }
     :global(table.rows td) { display: block; padding: 0; }


### PR DESCRIPTION
The homepage row highlight sat flush against the favicon (left) and the last format chip (right). Pulls the table out by a 16px bleed on both sides with matching first/last-cell padding, so the hover band gets breathing room while content stays on the container grid. Zeroed on mobile (flex rows). Build green; verified visually at desktop width — 16px gap on both edges.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/UsefulSoftwareCo/codesmith/integrationsdotsh/pr/28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785653081&installation_id=144115332&pr_number=28&repository=UsefulSoftwareCo%2Fintegrationsdotsh&return_to=https%3A%2F%2Fgithub.com%2FUsefulSoftwareCo%2Fintegrationsdotsh%2Fpull%2F28&signature=a3a54686986fd64c9bafdc52aba9123903c8f03060d3542a6bd42a6daa0b7ad3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->