### PR TITLE
Promote row-hover bleed to a shared --row-bleed token

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -265,10 +265,9 @@ const mono = (d: string) => (d[0] || "?").toUpperCase();
   .kinds button.active { color: var(--gray-1000); border-bottom-color: var(--gray-1000); }
   .kinds button span { opacity: 0.5; margin-left: 4px; }
 
-  /* The hover band bleeds past the content edges — flush against the favicon
-     and end chip it reads cramped. The table pulls back by the same amount so
-     the content itself stays on the container grid. 0 on mobile (flex rows). */
-  table.rows { --row-bleed: 16px; width: calc(100% + 2 * var(--row-bleed)); border-collapse: collapse; margin: 18px calc(-1 * var(--row-bleed)) 0; }
+  /* --row-bleed (global.css) bleeds the hover band past the content edges;
+     the table pulls back by the same amount so content stays on the grid. */
+  table.rows { width: calc(100% + 2 * var(--row-bleed)); border-collapse: collapse; margin: 18px calc(-1 * var(--row-bleed)) 0; }
   :global(table.rows tbody tr) { cursor: pointer; border-bottom: 1px solid var(--gray-100); }
   :global(table.rows tbody tr:hover) { background: var(--gray-25); }
   :global(table.rows td) { padding: 13px 20px 13px 0; vertical-align: middle; }
@@ -312,7 +311,6 @@ const mono = (d: string) => (d[0] || "?").toUpperCase();
      beneath themselves — the chips have the larger content width, so they give
      up space first. The table shrinks to the viewport instead of scrolling. */
   @media (max-width: 640px) {
-    table.rows { --row-bleed: 0px; }
     :global(table.rows), :global(table.rows tbody), :global(table.rows tfoot) { display: block; }
     :global(table.rows tr) { display: flex; align-items: center; gap: 12px; padding: 11px 0; }
     :global(table.rows td) { display: block; padding: 0; }

--- a/src/styles/discovery.css
+++ b/src/styles/discovery.css
@@ -20,7 +20,7 @@
 .disc-regenerate { font-family: var(--font-mono); font-size: 11.5px; color: var(--gray-700); }
 .disc-sec { margin-top: 40px; max-width: 760px; scroll-margin-top: 24px; }
 .disc-list { list-style: none; padding: 0; margin: 0; }
-.disc-entry { position: relative; border-bottom: 1px solid var(--gray-100); padding: 13px 0; }
+.disc-entry { position: relative; border-bottom: 1px solid var(--gray-100); padding: 13px var(--row-bleed); margin: 0 calc(-1 * var(--row-bleed)); }
 .disc-entry:has(a.disc-ename) { cursor: pointer; }
 .disc-entry:has(a.disc-ename):hover { background: var(--gray-25); }
 .disc-entry-head { display: flex; align-items: baseline; gap: 11px; }
@@ -37,7 +37,7 @@ a.disc-ename:hover { text-decoration: underline; text-underline-offset: 3px; }
 .conv-summary { cursor: pointer; width: max-content; max-width: 100%; }
 .conv-summary-text { text-transform: none; letter-spacing: 0; }
 .conv-list { list-style: none; padding: 0; margin: 10px 0 0; }
-.conv-row { position: relative; display: grid; grid-template-columns: minmax(136px, 0.32fr) 18px minmax(0, 1fr); gap: 10px; align-items: baseline; padding: 8px 0; border-bottom: 1px solid var(--gray-100); }
+.conv-row { position: relative; display: grid; grid-template-columns: minmax(136px, 0.32fr) 18px minmax(0, 1fr); gap: 10px; align-items: baseline; padding: 8px var(--row-bleed); margin: 0 calc(-1 * var(--row-bleed)); border-bottom: 1px solid var(--gray-100); }
 .conv-row:has(a.conv-name) { cursor: pointer; }
 .conv-row:has(a.conv-name):hover { background: var(--gray-25); }
 .conv-name { font-family: var(--font-mono); font-size: 12px; color: var(--gray-700); text-decoration: none; word-break: break-word; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,6 +8,10 @@
   --font-sans: "Geist", -apple-system, BlinkMacSystemFont, sans-serif;
   --font-mono: "Geist Mono", ui-monospace, "SF Mono", Menlo, monospace;
   --container: 1100px; color-scheme: light dark;
+  /* Row-hover bands bleed past their content edges by this much (favicons and
+     end chips otherwise read cramped against the band). Content stays on the
+     container grid; only the band extends. Zeroed on phones below. */
+  --row-bleed: 16px;
 }
 @media (prefers-color-scheme: dark) {
   :root {
@@ -31,7 +35,11 @@ a { color: inherit; }
 @media (max-width: 1140px) { .frame-guides { display: none; } }
 .container { max-width: var(--container); margin: 0 auto; padding: 0 40px; position: relative; z-index: 1; }
 /* On phones the 40px gutter eats a fifth of a 375px viewport — pull it in. */
-@media (max-width: 640px) { .container { padding: 0 20px; } }
+@media (max-width: 640px) {
+  .container { padding: 0 20px; }
+  /* The 20px gutter above is too tight to also give up to a bleeding band. */
+  :root { --row-bleed: 0px; }
+}
 
 nav.site { border-bottom: 1px solid var(--gray-100); background: var(--white); position: relative; z-index: 2; }
 nav.site .container { height: 64px; display: flex; align-items: center; gap: 32px; }


### PR DESCRIPTION
The hover-band bleed shipped for the homepage table in #28 was defined locally, while the same cramped-band flaw existed on the domain page: the surface list (.disc-entry) and convention rows (.conv-row) drew their hover band flush against the content on both edges. Moves --row-bleed to :root in global.css (zeroed under 640px where the container gutter is only 20px), applies it to both discovery.css row patterns, and simplifies index.astro to inherit the token. Verified at desktop width: 16px band out-dent on both edges, content and section headers stay on the container grid; build green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/UsefulSoftwareCo/codesmith/integrationsdotsh/pr/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785658034&installation_id=144115332&pr_number=29&repository=UsefulSoftwareCo%2Fintegrationsdotsh&return_to=https%3A%2F%2Fgithub.com%2FUsefulSoftwareCo%2Fintegrationsdotsh%2Fpull%2F29&signature=eb0fe2584054109cf9a816ad54493622cac096d34da2f106c81e1dc8c8beb97a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->