### PR TITLE
Add Context7 CLI and API surfaces alongside its MCP server

### DIFF
--- a/curated/context7.json
+++ b/curated/context7.json
@@ -1,0 +1,83 @@
+{
+  "slug": "context7",
+  "name": "Context7",
+  "tagline": "Up-to-date library docs and code examples, fetched straight into agent context.",
+  "description": "Context7 serves current, version-specific documentation for thousands of libraries so agents stop hallucinating APIs. It exposes a hosted MCP server, a REST API for library search and doc context, and the ctx7 CLI — all usable without credentials at reduced rate limits.",
+  "domain": "context7.com",
+  "icon": "https://context7.com/context7-icon-green.png",
+  "categories": [
+    "developer-tools",
+    "documentation"
+  ],
+  "auth": {
+    "methods": [
+      {
+        "type": "api_key",
+        "label": "API key",
+        "note": "Optional but recommended — free keys from the dashboard raise rate limits. Prefix ctx7sk-, shown only once at creation."
+      },
+      {
+        "type": "oauth2",
+        "label": "OAuth (MCP & CLI)",
+        "note": "Browser-based flow via ctx7 login or any OAuth-capable MCP client."
+      }
+    ],
+    "guide": "**Hosted MCP (fastest):** `https://mcp.context7.com/mcp` answers without credentials at reduced rate limits — point any client at it and it works. For higher limits, pass a key in the `CONTEXT7_API_KEY` header; OAuth-capable clients can authorize in the browser instead.\n\n```bash\nclaude mcp add --transport http context7 https://mcp.context7.com/mcp\n```\n\n**API key (REST):** create one from the [dashboard](https://context7.com/dashboard) (API Keys card → Create API Key). Keys start with `ctx7sk-` and are shown only once — copy immediately. Pass it as a standard bearer header; over-limit requests return `429` with `Retry-After` and `RateLimit-*` headers.\n\n```bash\ncurl \"https://context7.com/api/v2/libs/search?libraryName=react&query=hooks\" \\\n  -H \"Authorization: Bearer $CONTEXT7_API_KEY\"\n```\n\n**CLI:** `ctx7 login` opens a browser OAuth flow (`ctx7 whoami` to check); in CI or headless agents set `CONTEXT7_API_KEY` instead. `npx ctx7 setup` does it all in one shot — authenticates, mints a key, and configures your coding agent.\n\n```bash\nnpm i -g ctx7 && ctx7 login\n```",
+    "sources": [
+      {
+        "title": "Context7 Docs — API Guide",
+        "url": "https://context7.com/docs/api-guide"
+      },
+      {
+        "title": "Context7 Docs — Creating and managing API keys",
+        "url": "https://context7.com/docs/howto/api-keys"
+      },
+      {
+        "title": "Context7 Docs — The ctx7 CLI",
+        "url": "https://context7.com/docs/clients/cli"
+      },
+      {
+        "title": "GitHub — upstash/context7 (installation)",
+        "url": "https://github.com/upstash/context7#installation"
+      }
+    ],
+    "generatedAt": "2026-07-03",
+    "verified": true
+  },
+  "interfaces": [
+    {
+      "format": "mcp",
+      "name": "Context7 MCP",
+      "endpoint": "https://mcp.context7.com/mcp",
+      "auth": "mixed",
+      "authHeader": "CONTEXT7_API_KEY: {api_key}",
+      "docs": "https://context7.com/docs",
+      "note": "Works unauthenticated at reduced rate limits (probed: initialize succeeds without credentials). Streamable HTTP; OAuth advertised via WWW-Authenticate for clients that support it.",
+      "origin": "vendor"
+    },
+    {
+      "format": "openapi",
+      "name": "Context7 API",
+      "endpoint": "https://context7.com/api/v2",
+      "specUrl": "https://context7.com/docs/openapi.json",
+      "auth": "api_key",
+      "authHeader": "Authorization: Bearer {api_key}",
+      "docs": "https://context7.com/docs/api-guide",
+      "note": "Usable without a key at low rate limits. Library search, doc context, add/refresh sources, usage metrics.",
+      "origin": "vendor"
+    },
+    {
+      "format": "cli",
+      "name": "ctx7",
+      "install": "npm i -g ctx7 && ctx7 login",
+      "auth": "mixed",
+      "docs": "https://context7.com/docs/clients/cli",
+      "note": "OAuth via ctx7 login, or set CONTEXT7_API_KEY for non-interactive use. npx ctx7 setup authenticates, mints a key, and configures your coding agent in one step.",
+      "origin": "vendor"
+    }
+  ],
+  "links": {
+    "homepage": "https://context7.com",
+    "docs": "https://context7.com/docs"
+  }
+}

--- a/sources/cli.json
+++ b/sources/cli.json
@@ -20,6 +20,7 @@
     { "name": "aws", "domain": "amazonaws.com", "install": "brew install awscli && aws configure", "docs": "https://docs.aws.amazon.com/cli/", "description": "The AWS command-line interface across every AWS service." },
     { "name": "az", "domain": "azure.com", "install": "brew install azure-cli && az login", "docs": "https://learn.microsoft.com/cli/azure/", "description": "Manage Azure resources, identities, and deployments." },
     { "name": "linear", "domain": "linear.app", "install": "npm i -g @linear/cli && linear auth", "docs": "https://linear.app/developers", "description": "Create and manage Linear issues and projects from the terminal." },
-    { "name": "shopify", "domain": "shopify.com", "install": "npm i -g @shopify/cli && shopify auth login", "docs": "https://shopify.dev/docs/api/shopify-cli", "description": "Build, test, and deploy Shopify apps and themes." }
+    { "name": "shopify", "domain": "shopify.com", "install": "npm i -g @shopify/cli && shopify auth login", "docs": "https://shopify.dev/docs/api/shopify-cli", "description": "Build, test, and deploy Shopify apps and themes." },
+    { "name": "ctx7", "domain": "context7.com", "install": "npm i -g ctx7 && ctx7 login", "docs": "https://context7.com/docs/clients/cli", "description": "Fetch up-to-date library documentation and configure Context7 MCP for AI coding agents from the terminal." }
   ]
 }

--- a/sources/openapi-manual.json
+++ b/sources/openapi-manual.json
@@ -13,6 +13,19 @@
       "categories": ["cloud", "developer_tools"],
       "updated": "2026-06-29T00:00:00.000Z",
       "added": "2026-06-29T00:00:00.000Z"
+    },
+    {
+      "provider": "context7.com",
+      "providerName": "Context7",
+      "service": null,
+      "versionKey": "2.0.0",
+      "title": "Context7 Public API",
+      "description": "Programmatic access to up-to-date library documentation and code examples — search libraries and fetch documentation context for any query.",
+      "openapiVer": "3.0.0",
+      "origin": "https://context7.com/docs/openapi.json",
+      "categories": ["developer_tools"],
+      "updated": "2026-07-03T00:00:00.000Z",
+      "added": "2026-07-03T00:00:00.000Z"
     }
   ]
 }


### PR DESCRIPTION
## What

context7.com currently surfaces only its MCP server (from the Claude directory feed). This adds the other two vendor interfaces so the domain shows all three formats, plus a curated provider record. (I'm the developer behind Context7.)

- **`sources/cli.json`** — the `ctx7` CLI: `npm i -g ctx7 && ctx7 login` (OAuth; `CONTEXT7_API_KEY` env for headless), docs at https://context7.com/docs/clients/cli
- **`sources/openapi-manual.json`** — the Context7 Public API: origin spec at https://context7.com/docs/openapi.json (verified: serves OpenAPI 3.0.0, server `https://context7.com/api`)
- **`curated/context7.json`** — curated record per `curated/GENERATION.md`: grounded auth guide (key prefix `ctx7sk-`, `Authorization: Bearer` for REST, `CONTEXT7_API_KEY` header for MCP, 429/RateLimit-* behavior), sources limited to pages fetched during generation. `related` is left unset per the spec.

## Verification

- Probed `https://mcp.context7.com/mcp` with an unauthenticated `initialize`: answers `200` with a valid result (authless at reduced limits) and advertises OAuth via `WWW-Authenticate` — hence `auth: mixed` on the MCP interface
- `bun run normalize` passes; `output/index.json` shows `mcp/context7`, `openapi/context7-com`, and `cli/ctx7` all grouped under `context7.com`, search index reads `kinds: ["mcp","openapi","cli"]`, no duplicates (nothing for context7 in the discovered feed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/UsefulSoftwareCo/codesmith/integrationsdotsh/pr/30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785661684&installation_id=144115332&pr_number=30&repository=UsefulSoftwareCo%2Fintegrationsdotsh&return_to=https%3A%2F%2Fgithub.com%2FUsefulSoftwareCo%2Fintegrationsdotsh%2Fpull%2F30&signature=14de37bc0212e7120ce2887b64004aa815eff1dafe8ae16a3f2894b4d5a7df5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->