### PR TITLE
Link standard formats to their specs on the publishing page

### DIFF
--- a/src/pages/publishing.astro
+++ b/src/pages/publishing.astro
@@ -194,13 +194,13 @@ const promptExisting = `You are working inside my product's repository. I alread
 If you also author /.well-known/integrations.json, put everything in that one file: version + summary + a shared "credentials" map + a "surfaces" list of full surface objects. There is no index/reference layout — no separate per-surface files. Credentials are defined once in "credentials" and referenced from each surface's auth by id.`;
 
 const formats = [
-  { path: "/llms.txt", feeds: "Plain-language docs and product context.", adoption: "Use it when your docs have a good LLM-readable overview." },
-  { path: "/.well-known/api-catalog", feeds: "REST bases, OpenAPI links, docs, status pages, and MCP endpoints.", adoption: "Use RFC 9727 when you already publish a machine-readable service catalog." },
-  { path: "/openapi.json and conventional OpenAPI paths", feeds: "HTTP API surfaces and spec pointers.", adoption: "Publish one canonical OpenAPI document, then link alternates from your catalog if needed." },
-  { path: "/.well-known/mcp/server-card.json", feeds: "MCP server endpoint, transport, and auth metadata.", adoption: "Use it when agents can connect to an MCP server on your domain." },
-  { path: "/.well-known/oauth-protected-resource", feeds: "OAuth resource metadata, authorization servers, scopes, and self-onboarding support.", adoption: "Use it when an API or MCP endpoint is protected by OAuth." },
-  { path: "/.well-known/agent-card.json", feeds: "Agent-facing service identity.", adoption: "Use it to publish the agent card your site wants clients to read first." },
-  { path: "/.well-known/agent-skills/index.json", feeds: "Agent skill inventory.", adoption: "Use it when your domain publishes reusable skills or task instructions." },
+  { path: "/llms.txt", feeds: "Plain-language docs and product context.", adoption: "Use it when your docs have a good LLM-readable overview.", spec: "https://llmstxt.org", specLabel: "llmstxt.org" },
+  { path: "/.well-known/api-catalog", feeds: "REST bases, OpenAPI links, docs, status pages, and MCP endpoints.", adoption: "Use RFC 9727 when you already publish a machine-readable service catalog.", spec: "https://www.rfc-editor.org/rfc/rfc9727", specLabel: "RFC 9727" },
+  { path: "/openapi.json and conventional OpenAPI paths", feeds: "HTTP API surfaces and spec pointers.", adoption: "Publish one canonical OpenAPI document, then link alternates from your catalog if needed.", spec: "https://spec.openapis.org/oas/latest.html", specLabel: "OpenAPI spec" },
+  { path: "/.well-known/mcp/server-card.json", feeds: "MCP server endpoint, transport, and auth metadata.", adoption: "Use it when agents can connect to an MCP server on your domain.", spec: "https://modelcontextprotocol.io", specLabel: "modelcontextprotocol.io" },
+  { path: "/.well-known/oauth-protected-resource", feeds: "OAuth resource metadata, authorization servers, scopes, and self-onboarding support.", adoption: "Use it when an API or MCP endpoint is protected by OAuth.", spec: "https://www.rfc-editor.org/rfc/rfc9728", specLabel: "RFC 9728" },
+  { path: "/.well-known/agent-card.json", feeds: "Agent-facing service identity.", adoption: "Use it to publish the agent card your site wants clients to read first.", spec: "https://a2a-protocol.org", specLabel: "a2a-protocol.org" },
+  { path: "/.well-known/agent-skills/index.json", feeds: "Agent skill inventory.", adoption: "Use it when your domain publishes reusable skills or task instructions.", spec: "https://agentskills.io/specification", specLabel: "agentskills.io" },
   { path: "/.well-known/integrations.json", feeds: "Your declared v3 summary, credentials, and surfaces.", adoption: "Use it when you want this registry page to reflect your own integration map directly." },
 ];
 
@@ -258,12 +258,15 @@ const standardFormats = formats.filter((format) => format.path !== integrationsF
             aria-labelledby="formats-tab-standards"
           >
             <p>
-              Publish any or all of these open, official formats and we'll pick them up. Nothing here is proprietary to us.
+              Publish any or all of these open, official formats and we'll pick them up.
             </p>
             <div class="format-table">
               {standardFormats.map((format) => (
                 <div class="format-row">
-                  <code>{format.path}</code>
+                  <div class="format-id">
+                    <code>{format.path}</code>
+                    {format.spec && <a class="spec-link" href={format.spec} target="_blank" rel="noopener">{format.specLabel} ↗</a>}
+                  </div>
                   <p>{format.feeds}</p>
                   <p>{format.adoption}</p>
                 </div>
@@ -509,6 +512,9 @@ curl -sS https://your-domain.com/.well-known/mcp/server-card.json | jq . # if pu
   .format-detail { display: grid; grid-template-columns: minmax(190px, 0.55fr) minmax(0, 1fr) minmax(0, 1fr); gap: 18px; margin: 0 0 14px; padding: 13px 0; border-bottom: 1px solid var(--gray-100); align-items: baseline; }
   .format-row code, .format-detail code { color: var(--gray-1000); background: var(--gray-25); border: 1px solid var(--gray-100); border-radius: 4px; padding: 1px 5px; font-size: 12px; overflow-wrap: anywhere; }
   .format-row p, .format-detail p { margin: 0; color: var(--gray-500); font-size: 13px; line-height: 1.55; }
+  .format-id { display: flex; flex-direction: column; gap: 6px; align-items: flex-start; min-width: 0; }
+  .spec-link { font-family: var(--font-mono); font-size: 11px; color: var(--gray-500); text-decoration: none; border-bottom: 1px solid var(--gray-200); }
+  .spec-link:hover { color: var(--gray-1000); border-bottom-color: var(--gray-1000); }
   .own-code { margin: 14px 0; max-height: 560px; }
 
   @media (max-width: 720px) {


### PR DESCRIPTION
Each row in the Official standards tab now links to its spec definition (llmstxt.org, RFC 9727, OpenAPI spec, modelcontextprotocol.io, RFC 9728, a2a-protocol.org, agentskills.io) — same canonical URLs conventions.ts already uses. Also drops the "Nothing here is proprietary to us." aside.