### PR TITLE
Add ActivitySmith MCP integration

### DIFF
--- a/domains/activitysmith.com/integrations.json
+++ b/domains/activitysmith.com/integrations.json
@@ -1,0 +1,15 @@
+{
+  "description": "ActivitySmith sends iOS Push Notifications and updates Live Activities from developer tools, agent workflows, deployment pipelines, webhooks, and custom APIs.",
+  "discoveredAt": "2026-07-04T09:59:52.000Z",
+  "domain": "activitysmith.com",
+  "summary": "ActivitySmith exposes a hosted OAuth-protected MCP server at `https://mcp.activitysmith.com/mcp` for sending Push Notifications, updating Live Activities, managing channels, and working with related ActivitySmith tools.",
+  "surfaces": [
+    {
+      "authStatus": "required",
+      "name": "ActivitySmith MCP Server",
+      "slug": "activitysmith-mcp-server",
+      "type": "mcp",
+      "url": "https://mcp.activitysmith.com/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
- Add `activitysmith.com`

ActivitySmith exposes an official remote MCP server at `https://mcp.activitysmith.com/mcp` for agent-triggered iOS Push Notifications, Live Activities, Lock Screen Widget metrics, channels, devices, and API-key management.

Grounding:

- `GET https://mcp.activitysmith.com/mcp` without a token returns `401` with `www-authenticate: Bearer resource_metadata="https://mcp.activitysmith.com/.well-known/oauth-protected-resource"`.
- MCP `initialize` against the same endpoint without a token returns the same `401`, confirming the endpoint is live and auth-required.
- `GET https://mcp.activitysmith.com/.well-known/oauth-protected-resource` returns `200` with `resource: "https://mcp.activitysmith.com/mcp"`, `authorization_servers: ["https://activitysmith.com"]`, scopes `mcp:read` / `mcp:write`, and bearer header auth.
- `https://activitysmith.com/integrations/mcp-server` returns `200` and documents the same server URL, OAuth flow, Claude Code / Cursor / Codex setup, and MCP tool list.

This PR adds the compact discovered-domain record only: `domains/activitysmith.com/integrations.json`.