### PR TITLE
Add Solana: Helius and Jupiter integration surfaces

### DIFF
--- a/curated/helius.json
+++ b/curated/helius.json
@@ -1,0 +1,63 @@
+{
+  "slug": "helius",
+  "name": "Helius",
+  "tagline": "Solana RPC, DAS API, and an official MCP server for agents.",
+  "description": "Helius is a Solana developer platform: enhanced JSON-RPC, the Digital Asset Standard (DAS) API for reading tokens, NFTs, and compressed assets, webhooks, gRPC/WebSocket streaming, and transaction sending. It ships an official stdio MCP server that routes those tools to AI agents.",
+  "domain": "helius.dev",
+  "icon": "https://www.google.com/s2/favicons?domain=helius.dev&sz=64",
+  "categories": [
+    "blockchain",
+    "solana"
+  ],
+  "auth": {
+    "methods": [
+      {
+        "type": "api_key",
+        "label": "Helius API key",
+        "note": "Single key created in the Helius Dashboard; used by the RPC/DAS endpoints and the MCP server."
+      }
+    ],
+    "guide": "**API key (fastest):** create a key in the [Helius Dashboard](https://dashboard.helius.dev) and pass it as the `api-key` **query parameter** — not a header — on the RPC/DAS endpoint. The same endpoint serves standard Solana JSON-RPC and DAS methods (`getAssetsByOwner`, `searchAssets`, …):\n\n```bash\ncurl -s https://mainnet.helius-rpc.com/?api-key=$HELIUS_API_KEY \\\n  -X POST -H 'Content-Type: application/json' \\\n  -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getAssetsByOwner\",\"params\":{\"ownerAddress\":\"<wallet>\",\"page\":1}}'\n```\n\nDevnet is `https://devnet.helius-rpc.com/?api-key=$HELIUS_API_KEY`. `getHealth` responds without a key, but asset/RPC methods require one.\n\n**MCP server (for agents):** the official stdio server is the `helius-mcp` npm package. The Helius Claude Code plugin installs it plus skills and reference files in one step:\n\n```bash\nclaude plugin install helius@claude-plugins-official\n```\n\nSet the key in-session (`Set my Helius API key to $HELIUS_API_KEY`) or via environment before the server starts. Store keys in a secrets vault — never inline in committed config.",
+    "sources": [
+      {
+        "title": "Helius Docs — Agents",
+        "url": "https://www.helius.dev/docs/agents"
+      },
+      {
+        "title": "Helius Docs — Claude Code plugin",
+        "url": "https://www.helius.dev/docs/agents/claude-code-plugin"
+      },
+      {
+        "title": "helius-mcp on npm",
+        "url": "https://www.npmjs.com/package/helius-mcp"
+      }
+    ],
+    "generatedAt": "2026-07-04",
+    "verified": true
+  },
+  "interfaces": [
+    {
+      "format": "mcp",
+      "name": "Helius MCP",
+      "auth": "api_key",
+      "install": "npx -y helius-mcp@latest",
+      "docs": "https://www.helius.dev/docs/mcp",
+      "note": "Official stdio server (npm: helius-mcp). Routes ~10 tools across DAS, RPC, webhooks, streaming, and wallet analysis. Installed together with skills via the Helius Claude Code plugin.",
+      "origin": "vendor"
+    },
+    {
+      "format": "openapi",
+      "name": "Helius RPC & DAS API",
+      "endpoint": "https://mainnet.helius-rpc.com",
+      "auth": "api_key",
+      "authHeader": "?api-key={api_key}",
+      "docs": "https://www.helius.dev/docs",
+      "note": "Solana JSON-RPC + DAS over HTTP POST. Key is a query parameter, not a header. No public OpenAPI spec.",
+      "origin": "vendor"
+    }
+  ],
+  "links": {
+    "homepage": "https://www.helius.dev",
+    "docs": "https://www.helius.dev/docs"
+  }
+}

--- a/curated/jupiter.json
+++ b/curated/jupiter.json
@@ -1,0 +1,65 @@
+{
+  "slug": "jupiter",
+  "name": "Jupiter",
+  "tagline": "Solana swap aggregator and price API — free tier, no key to start.",
+  "description": "Jupiter routes and executes token swaps across Solana DEX liquidity and exposes Swap (quote/swap), Price, and Token REST APIs. A keyless tier lets an agent fetch quotes and prices immediately; a single Developer Platform key raises rate limits across every Jupiter API.",
+  "domain": "jup.ag",
+  "icon": "https://www.google.com/s2/favicons?domain=jup.ag&sz=64",
+  "categories": [
+    "blockchain",
+    "solana",
+    "defi"
+  ],
+  "auth": {
+    "methods": [
+      {
+        "type": "none",
+        "label": "Keyless (lite tier)",
+        "note": "lite-api.jup.ag needs no key — good for prototyping and low volume."
+      },
+      {
+        "type": "api_key",
+        "label": "Developer Platform key",
+        "note": "One key from the Jupiter Developer Platform unlocks higher rate limits across every Jupiter API."
+      }
+    ],
+    "guide": "**Keyless (start here):** the lite tier needs no credential. Fetch a price or a swap quote directly:\n\n```bash\ncurl 'https://lite-api.jup.ag/price/v3?ids=So11111111111111111111111111111111111111112'\ncurl 'https://lite-api.jup.ag/swap/v1/quote?inputMint=So111...112&outputMint=EPjF...Dt1v&amount=100000000&slippageBps=50'\n```\n\n**Developer Platform key (production):** create a key at the [Jupiter Developer Platform](https://developers.jup.ag/portal) and send it against the production host `https://api.jup.ag` in the `x-api-key` header. The same key works across Swap, Price, and Token APIs:\n\n```bash\ncurl 'https://api.jup.ag/price/v3?ids=So11111111111111111111111111111111111111112' \\\n  -H 'x-api-key: $JUP_API_KEY'\n```\n\nA missing/invalid key on `api.jup.ag` returns `401`. Keep keys in a secrets vault, not in committed config.",
+    "sources": [
+      {
+        "title": "Jupiter Developer Docs",
+        "url": "https://dev.jup.ag/docs/"
+      },
+      {
+        "title": "Jupiter Developer Platform (API keys)",
+        "url": "https://developers.jup.ag/portal"
+      }
+    ],
+    "generatedAt": "2026-07-04",
+    "verified": true
+  },
+  "interfaces": [
+    {
+      "format": "openapi",
+      "name": "Jupiter API (lite, keyless)",
+      "endpoint": "https://lite-api.jup.ag",
+      "auth": "none",
+      "docs": "https://dev.jup.ag/docs/",
+      "note": "Keyless tier. Swap quote at /swap/v1/quote, price at /price/v3. Rate-limited; no OpenAPI spec published.",
+      "origin": "vendor"
+    },
+    {
+      "format": "openapi",
+      "name": "Jupiter API (keyed)",
+      "endpoint": "https://api.jup.ag",
+      "auth": "api_key",
+      "authHeader": "x-api-key: {api_key}",
+      "docs": "https://dev.jup.ag/docs/",
+      "note": "Production host. One Developer Platform key raises limits across Swap/Price/Token APIs; invalid key returns 401.",
+      "origin": "vendor"
+    }
+  ],
+  "links": {
+    "homepage": "https://jup.ag",
+    "docs": "https://dev.jup.ag/docs/"
+  }
+}

--- a/domains/helius.dev/integrations.json
+++ b/domains/helius.dev/integrations.json
@@ -1,0 +1,21 @@
+{
+  "description": "Helius is a Solana RPC and developer-platform provider. It offers enhanced JSON-RPC, the Digital Asset Standard (DAS) API for reading tokens, NFTs, and compressed assets, webhooks, data streaming (LaserStream gRPC and WebSockets), and transaction-sending endpoints (Priority Fee API, Sender).",
+  "discoveredAt": "2026-07-04T09:59:10.303Z",
+  "domain": "helius.dev",
+  "summary": "Helius exposes a Solana JSON-RPC + DAS REST endpoint at `https://mainnet.helius-rpc.com` (API key passed as `?api-key=`), and ships an official stdio MCP server (`helius-mcp`, npm) that routes DAS, RPC, webhooks, streaming, and wallet tools to agents.",
+  "surfaces": [
+    {
+      "authStatus": "required",
+      "name": "Helius RPC & DAS API",
+      "slug": "helius-rpc-das-api",
+      "type": "http",
+      "url": "https://mainnet.helius-rpc.com"
+    },
+    {
+      "authStatus": "required",
+      "name": "Helius MCP server",
+      "slug": "helius-mcp-server",
+      "type": "mcp"
+    }
+  ]
+}

--- a/domains/jup.ag/integrations.json
+++ b/domains/jup.ag/integrations.json
@@ -1,0 +1,22 @@
+{
+  "description": "Jupiter is a Solana swap aggregator and liquidity API. It routes and executes token swaps across Solana DEX liquidity and exposes Swap (quote/swap), Price, and Token REST APIs used by wallets, bots, and agents to trade on Solana.",
+  "discoveredAt": "2026-07-04T09:59:10.303Z",
+  "domain": "jup.ag",
+  "summary": "Jupiter exposes REST APIs on two tiers: a free, no-key tier at `https://lite-api.jup.ag` (e.g. `/swap/v1/quote`, `/price/v3`) and a higher-rate keyed tier at `https://api.jup.ag` (`x-api-key` header, key from the Jupiter Developer Platform at developers.jup.ag/portal).",
+  "surfaces": [
+    {
+      "authStatus": "none",
+      "name": "Jupiter API (lite, no key)",
+      "slug": "jupiter-lite-api",
+      "type": "http",
+      "url": "https://lite-api.jup.ag"
+    },
+    {
+      "authStatus": "required",
+      "name": "Jupiter API (keyed)",
+      "slug": "jupiter-api-keyed",
+      "type": "http",
+      "url": "https://api.jup.ag"
+    }
+  ]
+}


### PR DESCRIPTION
## What this adds

The two flagship **Solana** providers — **Helius** and **Jupiter** — as their first Solana-native entries in the registry.

## Why they're missing today

The discovery pipeline is **spec-driven** (it seeds from OpenAPI / MCP-registry / GraphQL sources). Most major Solana APIs expose **JSON-RPC or custom REST without a published OpenAPI spec**, so they never get picked up automatically. The gap isn't lack of tooling — Solana has a very active agent/MCP ecosystem — it's that these surfaces need to be hand-authored. This PR does that for the two most-used providers.

## What's in each

For both providers, two layers:

| File | Purpose |
| --- | --- |
| `domains/<domain>/integrations.json` | Renders on the per-domain and per-surface pages (same schema as e.g. `domains/stripe.com/`). |
| `curated/<slug>.json` | Product-layer record per `curated/GENERATION.md`, carrying the grounded *how-to-authenticate* guide (including the stdio MCP install). |

- **Helius** (`helius.dev`) — Solana RPC + DAS API at `https://mainnet.helius-rpc.com` (key via `?api-key=`), plus the official stdio MCP server (`helius-mcp` on npm).
- **Jupiter** (`jup.ag`) — keyless lite tier at `https://lite-api.jup.ag` and a keyed production tier at `https://api.jup.ag` (`x-api-key` header).

## Grounding

Per the `curated/GENERATION.md` rules, every endpoint/auth fact was fetched or probed live while writing this:

- **Helius RPC** — `getHealth` → `{"result":"ok"}` (HTTP 200) at `https://mainnet.helius-rpc.com`; key is the `?api-key=` query param (not a header); official MCP is the `helius-mcp` npm package (v2.1.0, "Official Helius MCP Server").
- **Jupiter** — `https://lite-api.jup.ag/price/v3` and `/swap/v1/quote` return **200 keyless**; `https://api.jup.ag` rejects a bogus `x-api-key` with **401**, confirming the keyed header.
- Ran `bun run normalize` locally: both domains appear in the generated catalog with no new warnings.

## Notes / open questions

- **Helius's MCP is stdio-only** (no remote URL), so on the domain page it's a url-less `mcp` surface (there's precedent — ~268 committed url-less mcp surfaces); the full install command lives in the curated record. Happy to adjust if you have a preferred shape for stdio MCP servers.
- I included **both** the `domains/` and `curated/` layers since `curated/*.json` doesn't appear to be wired into the current build. If you'd rather I drop one layer (or seed `helius.dev`/`jup.ag` into a source list so regeneration preserves them), say the word and I'll update.
- Glad to follow up with more Solana providers (Magic Eden, Metaplex, Birdeye, Solscan, Pyth) in the same grounded style if this shape looks right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
