### PR TITLE
Fix OG images for zero-surface domains

### DIFF
--- a/src/lib/og.tsx
+++ b/src/lib/og.tsx
@@ -259,7 +259,10 @@ function Domain({ domain, doc, favicon }: { domain: string; doc: DiscoveryDoc; f
   const surfaces = doc.surfaces ?? [];
   const visible = surfaces.slice(0, 5);
   const hasOverflow = surfaces.length > 5;
-  const meta = `${surfaces.length.toLocaleString()} integrations · ${kinds(surfaces).join(" · ")}`;
+  const hasSurfaces = surfaces.length > 0;
+  const meta = hasSurfaces
+    ? [`${surfaces.length.toLocaleString()} integration${surfaces.length === 1 ? "" : "s"}`, ...kinds(surfaces)].join(" · ")
+    : "on the radar · no verified integration surfaces yet";
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%", width: "100%" }}>
       <div style={{ display: "flex", alignItems: "center", gap: 36 }}>
@@ -269,30 +272,61 @@ function Domain({ domain, doc, favicon }: { domain: string; doc: DiscoveryDoc; f
           <div style={{ fontFamily: monoFont, fontSize: 24, color: c.muted, marginTop: 12 }}>{meta}</div>
         </div>
       </div>
-      <div style={{
-        marginTop: 52,
-        position: "relative",
-        display: "flex",
-        flexDirection: "column",
-        ...(hasOverflow ? { maxHeight: 436, overflow: "hidden" as const } : {}),
-      }}>
-        {visible.map((surface) => (
-          <div key={surface.slug} style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "26px 4px", borderTop: `1px solid ${c.hairline}`, gap: 24 }}>
-            <span style={{ fontSize: 32, fontWeight: 500, letterSpacing: "-0.02em", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 650 }}>
-              {surface.name}
-            </span>
-            <span style={{ fontFamily: monoFont, fontSize: 22, color: c.muted, border: `1.5px solid ${c.chip}`, borderRadius: 8, padding: "6px 16px", whiteSpace: "nowrap" }}>
-              {rowSignature(surface, doc.credentials ?? {})}
-            </span>
-          </div>
-        ))}
-        {hasOverflow && (
-          <div style={{ position: "absolute", left: 0, right: 0, bottom: 0, height: 250, backgroundColor: c.bg, opacity: 0.92 }} />
-        )}
-      </div>
+      {hasSurfaces ? (
+        <div style={{
+          marginTop: 52,
+          position: "relative",
+          display: "flex",
+          flexDirection: "column",
+          ...(hasOverflow ? { maxHeight: 436, overflow: "hidden" as const } : {}),
+        }}>
+          {visible.map((surface) => (
+            <div key={surface.slug} style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "26px 4px", borderTop: `1px solid ${c.hairline}`, gap: 24 }}>
+              <span style={{ fontSize: 32, fontWeight: 500, letterSpacing: "-0.02em", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 650 }}>
+                {surface.name}
+              </span>
+              <span style={{ fontFamily: monoFont, fontSize: 22, color: c.muted, border: `1.5px solid ${c.chip}`, borderRadius: 8, padding: "6px 16px", whiteSpace: "nowrap" }}>
+                {rowSignature(surface, doc.credentials ?? {})}
+              </span>
+            </div>
+          ))}
+          {hasOverflow && (
+            <div style={{ position: "absolute", left: 0, right: 0, bottom: 0, height: 250, backgroundColor: c.bg, opacity: 0.92 }} />
+          )}
+        </div>
+      ) : (
+        <EmptyDomainBody />
+      )}
       <div style={{ position: "relative", marginTop: hasOverflow ? -30 : "auto", paddingTop: 40, display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
         <Wordmark />
         <SecLabel>how to integrate</SecLabel>
+      </div>
+    </div>
+  );
+}
+
+function EmptyDomainBody() {
+  const labels = ["API", "MCP", "GraphQL", "CLI"];
+  return (
+    <div style={{ marginTop: 36, display: "flex", flexDirection: "column", borderTop: `1px solid ${c.hairline}`, borderBottom: `1px solid ${c.hairline}`, padding: "28px 4px 24px" }}>
+      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 28 }}>
+        <div style={{ display: "flex", flexDirection: "column", maxWidth: 720 }}>
+          <span style={{ fontSize: 38, fontWeight: 600, letterSpacing: "-0.03em", lineHeight: 1.1 }}>No verified surfaces yet</span>
+          <span style={{ fontSize: 23, color: c.muted, lineHeight: 1.35, marginTop: 14 }}>
+            This domain is tracked in the registry while discovery waits for a confirmed REST, MCP, GraphQL, or CLI endpoint.
+          </span>
+        </div>
+        <span style={{ fontFamily: monoFont, fontSize: 20, color: c.muted, border: `1.5px solid ${c.chip}`, borderRadius: 8, padding: "7px 14px", whiteSpace: "nowrap" }}>
+          WATCHLIST
+        </span>
+      </div>
+      <div style={{ display: "flex", marginTop: 28, borderTop: `1px solid ${c.hairline}` }}>
+        {labels.map((label, index) => (
+          <div key={label} style={{ width: "25%", padding: "16px 18px 0 0", borderRight: index < labels.length - 1 ? `1px solid ${c.hairline}` : "none", display: "flex", flexDirection: "column" }}>
+            <span style={{ fontFamily: monoFont, fontSize: 18, color: c.muted, letterSpacing: "0.06em" }}>{label}</span>
+            <span style={{ fontSize: 20, color: c.fg, marginTop: 8 }}>pending signal</span>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/pages/disc/[domain].json.ts
+++ b/src/pages/disc/[domain].json.ts
@@ -8,12 +8,13 @@
  */
 import type { APIRoute } from "astro";
 import { all, domainById } from "~/lib/data.ts";
+import { allDomains } from "~/lib/catalog.ts";
 import { baselineDiscoveryGroups, catalogDiscovery } from "~/lib/catalog-to-discovery.ts";
 
 const groups = baselineDiscoveryGroups(all, (r) => domainById.get(r.id) || r.slug);
 
 export function getStaticPaths() {
-  return [...groups.keys()].map((domain) => ({ params: { domain } }));
+  return allDomains().map(({ domain }) => ({ params: { domain } }));
 }
 
 export const GET: APIRoute = ({ params }) => {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,7 +16,7 @@ const TLABEL: Record<string, string> = { mcp: "MCP", openapi: "API", graphql: "G
 const mono = (d: string) => (d[0] || "?").toUpperCase();
 ---
 
-<Base title="integrations.sh — every integration, in every format agents speak" path="/">
+<Base title="integrations.sh — every integration, in every format agents speak" path="/" ogImagePath="/og.png">
   <div class="container">
     <section class="hero">
       <h1>Every integration, in every format agents speak.</h1>

--- a/worker/discovery-doc.test.ts
+++ b/worker/discovery-doc.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { discoveryDoc } from "./discovery-doc.ts";
+import type { Env } from "./env.ts";
+
+const origin = "https://integrations.sh";
+
+function envWith(options: { kv?: Record<string, string>; baseline?: unknown }): Env {
+  return {
+    DISCOVERY: {
+      get: async (key: string) => options.kv?.[key] ?? null,
+      put: async () => {},
+    },
+    ASSETS: {
+      fetch: async () =>
+        options.baseline
+          ? new Response(JSON.stringify(options.baseline), { headers: { "content-type": "application/json" } })
+          : new Response(null, { status: 404 }),
+    },
+  } as unknown as Env;
+}
+
+describe("discoveryDoc", () => {
+  test("returns stored zero-surface docs", async () => {
+    const discoveredAt = "2026-07-05T19:00:00.000Z";
+    const result = { version: 3, domain: "empty.com", summary: "No surfaces found.", credentials: {}, surfaces: [] };
+    const doc = await discoveryDoc(
+      envWith({ kv: { "empty.com": JSON.stringify({ result, discoveredAt, model: "test" }) } }),
+      origin,
+      "empty.com",
+    );
+
+    expect(doc).toEqual({ ...result, discoveredAt });
+  });
+
+  test("returns baseline zero-surface docs", async () => {
+    const baseline = { version: 3, domain: "baseline.com", summary: "", credentials: {}, surfaces: [] };
+    const doc = await discoveryDoc(envWith({ baseline }), origin, "baseline.com");
+
+    expect(doc).toEqual(baseline);
+  });
+
+  test("returns null for genuinely unknown domains", async () => {
+    await expect(discoveryDoc(envWith({}), origin, "missing.com")).resolves.toBeNull();
+  });
+});

--- a/worker/discovery-doc.ts
+++ b/worker/discovery-doc.ts
@@ -18,8 +18,15 @@ export async function discoveryKvGet(env: Env, domain: string): Promise<string |
  * loader feeds the `/api/{domain}/discovery` JSON endpoint (the island's mount
  * fetch) and the OG image, so filtering here keeps them consistent with the
  * SSR'd pages. */
-const stripSdkSurfaces = (doc: DiscoverData): DiscoverData =>
-  doc.surfaces?.length ? { ...doc, surfaces: doc.surfaces.filter((s) => !isSdkNotCli(s)) } : doc;
+type DiscoveryDocWithSurfaces = DiscoverData & { surfaces: NonNullable<DiscoverData["surfaces"]> };
+
+const hasSurfaceArray = (doc: DiscoverData | undefined): doc is DiscoveryDocWithSurfaces =>
+  Array.isArray(doc?.surfaces);
+
+const stripSdkSurfaces = (doc: DiscoveryDocWithSurfaces): DiscoveryDocWithSurfaces => ({
+  ...doc,
+  surfaces: doc.surfaces.filter((s) => !isSdkNotCli(s)),
+});
 
 /** The domain page's render source: durable discovery result first, then the
  * prerendered baseline discovery JSON. */
@@ -29,14 +36,14 @@ export async function discoveryDoc(env: Env, origin: string, domain: string): Pr
     const raw = await discoveryKvGet(env, canonical);
     if (raw) {
       const stored = JSON.parse(raw) as { result?: DiscoverData; discoveredAt?: string };
-      if (stored.result?.surfaces?.length) {
+      if (hasSurfaceArray(stored.result)) {
         return stripSdkSurfaces({ ...stored.result, discoveredAt: stored.result.discoveredAt ?? stored.discoveredAt });
       }
     }
     const res = await env.ASSETS.fetch(`${origin}/disc/${encodeURIComponent(canonical)}.json`);
     if (res.ok) {
       const baseline = (await res.json()) as DiscoverData;
-      if (baseline.surfaces?.length) return stripSdkSurfaces(baseline);
+      if (hasSurfaceArray(baseline)) return stripSdkSurfaces(baseline);
     }
   } catch {
     /* unavailable or malformed discovery data */

--- a/worker/entry.ts
+++ b/worker/entry.ts
@@ -177,7 +177,7 @@ async function ogResponse(request: Request, env: Env, ctx: ExecutionContext, cac
     const domain = registrableDomain(decodeURIComponent(match[1]).trim().toLowerCase());
     if (!domain) return null;
     const doc = await discoveryDoc(env, url.origin, domain);
-    if (!doc?.surfaces?.length) return null;
+    if (!doc || !Array.isArray(doc.surfaces)) return null;
 
     const favicon = await faviconData(url.origin, domain);
     const slug = match[2] ? decodeURIComponent(match[2]) : "";


### PR DESCRIPTION
Domains without verified surfaces had pages that declared an og:image, but /og/<domain>.png returned 404 (~420 of 3231 sitemap domains). The worker now renders a proper empty-state card for those domains, and static /disc JSON covers them too. Also adds the homepage og:image, which was never wired up.