### PR TITLE
Seed discovery with llms.txt content

### DIFF
--- a/src/lib/conventions.test.ts
+++ b/src/lib/conventions.test.ts
@@ -11,7 +11,6 @@ describe("buildConventionRows", () => {
           url: "https://example.com/.well-known/integrations.json",
           result: { version: 3 },
         },
-        llmsTxt: false,
       },
       "example.com",
     );
@@ -38,11 +37,13 @@ describe("buildConventionRows", () => {
     const rows = buildConventionRows(
       {
         probed: [
+          PROBE_KEYS.llmsTxt,
           PROBE_KEYS.apiCatalog,
           PROBE_KEYS.openapiSchema,
           PROBE_KEYS.oauthProtectedResource,
           PROBE_KEYS.agentSkills,
         ],
+        llmsTxt: { url: "https://example.com/llms.txt", content: "# Docs" },
         apiCatalog: { rest: ["https://api.example.com"], openapi: ["https://example.com/openapi.json"] },
         apiSchema: { url: "https://example.com/openapi.json", format: "openapi", version: "3.1.0" },
         auth: {
@@ -56,6 +57,10 @@ describe("buildConventionRows", () => {
       "example.com",
     );
 
+    expect(rows.find((row) => row.key === PROBE_KEYS.llmsTxt)).toMatchObject({
+      detail: "https://example.com/llms.txt",
+      specHref: "https://llmstxt.org",
+    });
     expect(rows.find((row) => row.key === PROBE_KEYS.apiCatalog)).toMatchObject({
       detail: "https://example.com/.well-known/api-catalog",
       specHref: "https://www.rfc-editor.org/rfc/rfc9727",

--- a/src/lib/conventions.ts
+++ b/src/lib/conventions.ts
@@ -103,8 +103,9 @@ export function buildConventionRows(detectValue: unknown, domain: string): Conve
       "/publishing/",
     ),
     row(detect, PROBE_KEYS.llmsTxt, "llms.txt", LLMS_TXT_PATH, () => {
-      if (detect?.llmsTxt !== true) return null;
-      const url = pathUrl(domain, LLMS_TXT_PATH);
+      const value = detect?.llmsTxt;
+      if (value !== true && !isRecord(value)) return null;
+      const url = isRecord(value) && typeof value.url === "string" ? value.url : pathUrl(domain, LLMS_TXT_PATH);
       return { detail: url, valueUrl: url };
     }, "https://llmstxt.org"),
     row(detect, PROBE_KEYS.apiCatalog, "API catalog", API_CATALOG_PATH, () => {

--- a/src/lib/detect.test.ts
+++ b/src/lib/detect.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { PROBE_KEYS } from "./conventions.ts";
+import { detect, type FetchLike } from "./detect.ts";
+
+function fetchWithLlmsTxt(body: string, init?: ResponseInit): { fetchImpl: FetchLike; urls: string[] } {
+  const urls: string[] = [];
+  const fetchImpl: FetchLike = async (url) => {
+    const href = String(url);
+    urls.push(href);
+    if (href === "https://example.com/llms.txt") return new Response(body, init);
+    return new Response("not found", { status: 404 });
+  };
+  return { fetchImpl, urls };
+}
+
+describe("detect llms.txt", () => {
+  test("carries llms.txt content through the detection result", async () => {
+    const content = "# Example docs\n\n- [API](https://example.com/docs/api)";
+    const { fetchImpl, urls } = fetchWithLlmsTxt(content, { status: 200, headers: { "content-type": "text/plain" } });
+
+    const result = await detect("example.com", fetchImpl);
+
+    expect(result.llmsTxt).toEqual({
+      url: "https://example.com/llms.txt",
+      content,
+    });
+    expect(result.found).toContain(PROBE_KEYS.llmsTxt);
+    expect(urls.filter((url) => url === "https://example.com/llms.txt")).toHaveLength(1);
+  });
+
+  test("rejects an HTML response masquerading as llms.txt", async () => {
+    const { fetchImpl } = fetchWithLlmsTxt(" \n<!doctype html><title>Not found</title>", {
+      status: 200,
+      headers: { "content-type": "text/plain" },
+    });
+
+    const result = await detect("example.com", fetchImpl);
+
+    expect(result.llmsTxt).toBeUndefined();
+    expect(result.found).not.toContain(PROBE_KEYS.llmsTxt);
+  });
+
+  test("treats an empty llms.txt response as absent", async () => {
+    const { fetchImpl } = fetchWithLlmsTxt("", { status: 200 });
+
+    const result = await detect("example.com", fetchImpl);
+
+    expect(result.llmsTxt).toBeUndefined();
+    expect(result.found).not.toContain(PROBE_KEYS.llmsTxt);
+  });
+});

--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -46,6 +46,11 @@ export interface IntegrationsJsonDetection {
   result: OwnerDeclaredDiscovery;
 }
 
+export interface LlmsTxtDetection {
+  url: string;
+  content: string;
+}
+
 export interface DetectionResult {
   domain: string;
   /** Signals that were actually found, for a quick readiness summary. */
@@ -79,7 +84,7 @@ export interface DetectionResult {
   mcp: McpDetection[];
   agentCard?: { name?: string; url?: string };
   agentSkills?: { count: number; names: string[] };
-  llmsTxt: boolean;
+  llmsTxt?: LlmsTxtDetection;
   errors: string[];
 }
 
@@ -232,10 +237,13 @@ async function checkAgentSkills(fetchImpl: FetchLike, domain: string) {
   return { count: doc.skills.length, names: doc.skills.map((s: any) => s.name).filter(Boolean).slice(0, 50) };
 }
 
-async function checkLlmsTxt(fetchImpl: FetchLike, domain: string): Promise<boolean> {
-  const hit = await get(fetchImpl, `https://${domain}${LLMS_TXT_PATH}`);
-  if (!hit || !hit.res.ok) return false;
-  return hit.text.length > 0 && !/<!doctype|<html/i.test(hit.text.slice(0, 200));
+async function checkLlmsTxt(fetchImpl: FetchLike, domain: string): Promise<LlmsTxtDetection | undefined> {
+  const url = `https://${domain}${LLMS_TXT_PATH}`;
+  const hit = await get(fetchImpl, url);
+  if (!hit || !hit.res.ok || hit.text.length === 0) return undefined;
+  const head = hit.text.trimStart().slice(0, 200);
+  if (/^(?:<!doctype|<html)\b/i.test(head)) return undefined;
+  return { url, content: hit.text };
 }
 
 async function checkIntegrationsJson(fetchImpl: FetchLike, domain: string): Promise<IntegrationsJsonDetection | null> {
@@ -379,7 +387,7 @@ export async function detect(domain: string, fetchImpl: FetchLike = fetch): Prom
     checkServerCard(fetchImpl, domain).catch((e) => (errors.push(`server-card: ${e}`), undefined)),
     checkAgentCard(fetchImpl, domain).catch((e) => (errors.push(`agent-card: ${e}`), undefined)),
     checkAgentSkills(fetchImpl, domain).catch((e) => (errors.push(`agent-skills: ${e}`), undefined)),
-    checkLlmsTxt(fetchImpl, domain).catch(() => false),
+    checkLlmsTxt(fetchImpl, domain).catch(() => undefined),
     checkApiSchema(fetchImpl, domain).catch(() => undefined),
     checkApiOAuth(fetchImpl, domain).catch(() => undefined),
   ]);

--- a/src/lib/discover.test.ts
+++ b/src/lib/discover.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { PROBE_KEYS } from "./conventions.ts";
+import { discover, type ChatFn, type WebBackend } from "./discover.ts";
+import type { DetectionResult } from "./detect.ts";
+
+const web: WebBackend = {
+  canSearch: true,
+  search: async () => [],
+  scrape: async () => "",
+  sitemap: async () => [],
+};
+
+function baseDetection(content: string): DetectionResult {
+  return {
+    domain: "example.com",
+    found: [PROBE_KEYS.llmsTxt],
+    probed: [PROBE_KEYS.llmsTxt],
+    mcp: [],
+    llmsTxt: {
+      url: "https://example.com/llms.txt",
+      content,
+    },
+    errors: [],
+  };
+}
+
+async function initialUserPrompt(detect: DetectionResult): Promise<string> {
+  let prompt = "";
+  const chat: ChatFn = async (messages) => {
+    prompt = String((messages[1] as { content?: unknown }).content ?? "");
+    return {
+      message: { role: "assistant", content: null },
+      toolCalls: [
+        {
+          id: "finish-1",
+          name: "finish",
+          arguments: {
+            summary: "No public developer integration surfaces were found.",
+            description: "Example is a test service.",
+          },
+        },
+      ],
+    };
+  };
+
+  await discover("example.com", detect, chat, web);
+  return prompt;
+}
+
+describe("discover llms.txt seed facts", () => {
+  test("inlines llms.txt content as a documentation index", async () => {
+    const prompt = await initialUserPrompt(baseDetection("# Example docs\n- https://example.com/docs/api"));
+
+    expect(prompt).toContain("The domain publishes an llms.txt at https://example.com/llms.txt — a plain-text index of its documentation. Contents:");
+    expect(prompt).toContain("<<<llms.txt\n# Example docs\n- https://example.com/docs/api\n>>>");
+    expect(prompt).not.toContain("fallback");
+  });
+
+  test("truncates inlined llms.txt content at the cap on a line boundary", async () => {
+    const firstLine = "a".repeat(39_990);
+    const partialLine = "this-line-must-not-appear";
+    const prompt = await initialUserPrompt(baseDetection(`${firstLine}\n${partialLine}\n`));
+
+    expect(prompt).toContain(`${firstLine}\n[llms.txt truncated at 40000 chars — full file at https://example.com/llms.txt]`);
+    expect(prompt).not.toContain(partialLine);
+  });
+});

--- a/src/lib/discover.ts
+++ b/src/lib/discover.ts
@@ -241,7 +241,8 @@ const SYSTEM =
   "- For authStatus=required, `auth` is the OR alternatives (any one works). Each entry's `use` is the credentials sent TOGETHER (AND), and EACH use carries its OWN `mechanics` — so an app-id in one header and an api-key in a differently-named header are two uses in one entry, each with its own placement.\n\n" +
   "Each use's mechanics.source tells where its binding resolves from: 'spec' (give the ONE OpenAPI securityScheme name this credential satisfies, in `scheme`), 'well-known' (MCP OAuth, derives from the url), 'http' (you read it from docs — give in/headerName/scheme), 'cli' (command/env), or 'unknown' (it exists but you couldn't pin the mechanics).\n\n" +
   "How to work — page by page:\n" +
-  "- Start with web_search to find the key developer pages. Then read the most relevant with scrape_page — issue SEVERAL scrape_page calls in the SAME turn so they run in parallel; don't read one, wait, read the next.\n" +
+  "- If seed facts include llms.txt contents, use them as the starting index for which docs pages to scrape; web_search can fill gaps, and scrape_page is still how you read the actual pages.\n" +
+  "- Otherwise start with web_search to find the key developer pages. Then read the most relevant with scrape_page — issue SEVERAL scrape_page calls in the SAME turn so they run in parallel; don't read one, wait, read the next.\n" +
   "- After a batch of reads, record_credential / record_surface for what those pages revealed before reading more. Pass `evidence` (the doc URLs you read) on each surface and auth entry.\n" +
   "- Catalog facts are authoritative like detect signals: include a surface for each catalog fact, enrich it with docs/auth, and never contradict them.\n" +
   "- Capture spec/schema URLs as POINTERS; never inline a spec. Only state URLs/endpoints you actually saw. Never invent them.\n" +
@@ -268,6 +269,7 @@ const SYSTEM =
 const MAX_STEPS = 16;
 const MAX_SCRAPES = 30; // runaway guard, not a doc cap
 const PER_DOC_CHARS = 8000;
+export const LLMS_TXT_SEED_CONTENT_CHAR_LIMIT = 40_000;
 
 // ── the loop ───────────────────────────────────────────────────────────────────
 
@@ -437,8 +439,23 @@ function seedFacts(domain: string, detect: DetectionResult): string[] {
   for (const m of detect.mcp ?? []) facts.push(`MCP server endpoint: ${m.url}${m.auth ? ` (auth: ${m.auth})` : ""}`);
   if (detect.apiSchema) facts.push(`OpenAPI spec published at ${detect.apiSchema.url}`);
   if (detect.apiCatalog?.docs?.length) facts.push(`Docs linked from api-catalog: ${detect.apiCatalog.docs.join(", ")}`);
-  if (detect.llmsTxt) facts.push(`A plain-text llms.txt exists at https://${domain}/llms.txt — a fallback to scrape only if web_search doesn't surface the developer docs.`);
+  if (detect.llmsTxt) {
+    const url = detect.llmsTxt.url || `https://${domain}/llms.txt`;
+    facts.push(
+      `The domain publishes an llms.txt at ${url} — a plain-text index of its documentation. Contents:\n` +
+      `<<<llms.txt\n${truncateLlmsTxtContent(detect.llmsTxt.content, url)}\n>>>`,
+    );
+  }
   return facts;
+}
+
+function truncateLlmsTxtContent(content: string, url: string): string {
+  if (content.length <= LLMS_TXT_SEED_CONTENT_CHAR_LIMIT) return content;
+  const capped = content.slice(0, LLMS_TXT_SEED_CONTENT_CHAR_LIMIT);
+  const boundary = capped.lastIndexOf("\n");
+  const body = boundary >= 0 ? capped.slice(0, boundary) : capped;
+  const marker = `[llms.txt truncated at ${LLMS_TXT_SEED_CONTENT_CHAR_LIMIT} chars — full file at ${url}]`;
+  return `${body}${body.endsWith("\n") || body.length === 0 ? "" : "\n"}${marker}`;
 }
 
 function ownerDeclarationPrompt(detect: DetectionResult): string {

--- a/worker/entry.ts
+++ b/worker/entry.ts
@@ -31,7 +31,7 @@ import { McpDurableObject } from "./mcp-do.ts";
 
 // Bump when detect/discover output shape or logic changes, so the edge Cache API
 // (which survives deploys) stops serving results produced by the old code.
-const CACHE_VERSION = "19"; // 19: live search index reads from DISCOVERY
+const CACHE_VERSION = "20"; // 20: llms.txt content seeds discovery
 
 // The discovery-loop model. gpt-5.4 drives the agentic tool-calling loop
 // (search/sitemap/scrape/report). (Note: gpt-5.x rejects `reasoning_effort`

--- a/worker/operations.ts
+++ b/worker/operations.ts
@@ -27,7 +27,7 @@ export const DetectionResult = Schema.Struct({
   mcp: Schema.Array(Schema.Unknown),
   agentCard: Schema.optional(Schema.Unknown),
   agentSkills: Schema.optional(Schema.Unknown),
-  llmsTxt: Schema.Boolean,
+  llmsTxt: Schema.optional(Schema.Struct({ url: Schema.String, content: Schema.String })),
   errors: Schema.Array(Schema.String),
 });
 


### PR DESCRIPTION
The detect step was only recording whether llms.txt exists, and the discovery agent was told to treat it as a scrape fallback. Now the detect result carries the file's content and it's inlined into the agent's seed facts as a documentation index (capped at 40k chars). HTML pages served at /llms.txt are treated as absent.