### PR TITLE
Prefetch links on hover

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -14,6 +14,9 @@ const satoriWasmEntry = fileURLToPath(new URL("./node_modules/satori/dist/index.
 // Object alongside the Astro fetch handler.
 export default defineConfig({
   site: "https://integrations.sh",
+  prefetch: {
+    defaultStrategy: "hover",
+  },
   output: "static",
   adapter: cloudflare({
     workerEntryPoint: {


### PR DESCRIPTION
Enables Astro link prefetching on hover so navigations can feel a bit faster without prefetching every visible link.