### PR TITLE
Update repo references after rename

### DIFF
--- a/.github/workflows/sync-discovered.yml
+++ b/.github/workflows/sync-discovered.yml
@@ -58,7 +58,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          stars=$(gh api repos/UsefulSoftwareCo/integrationsdotsh --jq .stargazers_count)
+          stars=$(gh api repos/UsefulSoftwareCo/integrations --jq .stargazers_count)
           case "$stars" in
             ''|*[!0-9]*)
               echo "Invalid GitHub star count: $stars"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Readable by you and your agent.
   <img alt="Cloudflare Workers" src="https://img.shields.io/badge/edge-Cloudflare_Workers-F38020?style=flat-square&logo=cloudflare&logoColor=white">
   <img alt="MCP" src="https://img.shields.io/badge/exposes-MCP_server-000?style=flat-square">
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-111?style=flat-square"></a>
-  <a href="https://github.com/UsefulSoftwareCo/integrationsdotsh/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/UsefulSoftwareCo/integrationsdotsh?style=flat-square"></a>
+  <a href="https://github.com/UsefulSoftwareCo/integrations/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/UsefulSoftwareCo/integrations?style=flat-square"></a>
 </p>
 
 </div>
@@ -110,7 +110,7 @@ curl https://integrations.sh/api/stripe.com/detect
 ## Project layout
 
 ```
-integrationsdotsh/
+integrations/
 ├─ src/
 │  ├─ pages/            # routes — homepage, [domain], surface pages, api.json, /disc/*
 │  ├─ components/       # Nav, DomainPage, Surfaces (the explorer island), …

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -14,7 +14,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import seed from "~/data/github-stars.json";
 
-const REPO = "UsefulSoftwareCo/integrationsdotsh";
+const REPO = "UsefulSoftwareCo/integrations";
 const GITHUB_STARS_URL = `https://api.github.com/repos/${REPO}`;
 const STARS_CACHE_DIR = "node_modules/.cache/integrationsdotsh";
 const STARS_CACHE_FILE = `${STARS_CACHE_DIR}/github-stars.json`;

--- a/src/pages/api/stars.json.ts
+++ b/src/pages/api/stars.json.ts
@@ -11,7 +11,7 @@ import type { EdgeCaches, Fetcher } from "../../../worker/env.ts";
 
 export const prerender = false;
 
-const GITHUB_STARS_URL = "https://api.github.com/repos/UsefulSoftwareCo/integrationsdotsh";
+const GITHUB_STARS_URL = "https://api.github.com/repos/UsefulSoftwareCo/integrations";
 const LONG_CACHE_CONTROL = "public, max-age=3600, s-maxage=3600";
 const SHORT_CACHE_CONTROL = "public, max-age=300, s-maxage=300";
 


### PR DESCRIPTION
The GitHub repo was renamed integrationsdotsh -> integrations. Updates the stars API URLs, the README badge and layout heading, and the sync workflow to the new name.