### PR TITLE
Collapse duplicate MCP surfaces across host variants

### DIFF
--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -28,5 +28,10 @@ jobs:
       - name: Dedup unit tests
         run: bun test src/lib/dedup.test.ts
 
+      # The validator pulls in the catalog seed (output/catalog-seeds.json), a
+      # gitignored generated file. normalize regenerates it from domains/.
+      - name: Generate catalog data
+        run: bun run normalize
+
       - name: Validate catalog for duplicate surfaces
         run: bun run validate:duplicates

--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -1,0 +1,32 @@
+name: Validate catalog
+
+# Blocks a PR that introduces a duplicate surface — the same server listed twice
+# under cosmetic host variants (slack.com/mcp vs mcp.slack.com/mcp) or two labels
+# for one endpoint. Scoped to that failure class via --fail-on, so the 700+
+# pre-existing data-quality findings stay non-blocking (still printed).
+on:
+  pull_request:
+    paths:
+      - "domains/**"
+      - "scripts/batch/**"
+      - "src/lib/dedup.ts"
+      - ".github/workflows/validate-catalog.yml"
+
+jobs:
+  duplicates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Dedup unit tests
+        run: bun test src/lib/dedup.test.ts
+
+      - name: Validate catalog for duplicate surfaces
+        run: bun run validate:duplicates

--- a/domains/fotocasa.es/integrations.json
+++ b/domains/fotocasa.es/integrations.json
@@ -12,13 +12,6 @@
       "url": "https://fotocasa.es/mcp"
     },
     {
-      "authStatus": "none",
-      "name": "Fotocasa MCP Server",
-      "slug": "fotocasa-mcp-server",
-      "type": "mcp",
-      "url": "https://www.fotocasa.es/mcp"
-    },
-    {
       "authStatus": "unknown",
       "name": "Fotocasa Mobile Web Service v2",
       "slug": "fotocasa-mobile-web-service-v2",

--- a/domains/goupword.com/integrations.json
+++ b/domains/goupword.com/integrations.json
@@ -17,13 +17,6 @@
       "slug": "mcp-server",
       "type": "mcp",
       "url": "https://www.goupword.com/.well-known/mcp/server-card.json"
-    },
-    {
-      "authStatus": "required",
-      "name": "upword MCP server",
-      "slug": "upword-mcp-server",
-      "type": "mcp",
-      "url": "https://www.goupword.com/mcp"
     }
   ]
 }

--- a/domains/meterplan.com/integrations.json
+++ b/domains/meterplan.com/integrations.json
@@ -13,13 +13,6 @@
     },
     {
       "authStatus": "none",
-      "name": "Meter Energy MCP Server",
-      "slug": "meter-energy-mcp-server",
-      "type": "mcp",
-      "url": "https://meterplan.com/mcp"
-    },
-    {
-      "authStatus": "none",
       "name": "Texas Electricity MCP Server",
       "slug": "texas-electricity-mcp-server",
       "type": "mcp",

--- a/domains/primitive.dev/integrations.json
+++ b/domains/primitive.dev/integrations.json
@@ -27,13 +27,6 @@
     },
     {
       "authStatus": "required",
-      "name": "Primitive MCP server",
-      "slug": "primitive-mcp-server",
-      "type": "mcp",
-      "url": "https://www.primitive.dev/mcp"
-    },
-    {
-      "authStatus": "required",
       "command": "primitive",
       "name": "primitive CLI",
       "packages": [

--- a/domains/send.co/integrations.json
+++ b/domains/send.co/integrations.json
@@ -10,13 +10,6 @@
       "slug": "mcp-server",
       "type": "mcp",
       "url": "https://send.co/mcp"
-    },
-    {
-      "authStatus": "required",
-      "name": "Send MCP server",
-      "slug": "send-mcp-server",
-      "type": "mcp",
-      "url": "https://www.send.co/mcp"
     }
   ]
 }

--- a/domains/slack.com/integrations.json
+++ b/domains/slack.com/integrations.json
@@ -6,13 +6,6 @@
   "surfaces": [
     {
       "authStatus": "required",
-      "name": "MCP server",
-      "slug": "mcp-server",
-      "type": "mcp",
-      "url": "https://slack.com/mcp"
-    },
-    {
-      "authStatus": "required",
       "name": "Slack Web API",
       "slug": "slack-web-api",
       "type": "http",

--- a/domains/success.co/integrations.json
+++ b/domains/success.co/integrations.json
@@ -25,13 +25,6 @@
       "spec": "introspection",
       "type": "graphql",
       "url": "https://www.success.co/graphql"
-    },
-    {
-      "authStatus": "required",
-      "name": "Success.co MCP server",
-      "slug": "success-co-mcp-server",
-      "type": "mcp",
-      "url": "https://www.success.co/mcp"
     }
   ]
 }

--- a/domains/trykopi.ai/integrations.json
+++ b/domains/trykopi.ai/integrations.json
@@ -10,13 +10,6 @@
       "slug": "mcp-server",
       "type": "mcp",
       "url": "https://trykopi.ai/mcp"
-    },
-    {
-      "authStatus": "required",
-      "name": "Kopi MCP Server",
-      "slug": "kopi-mcp-server",
-      "type": "mcp",
-      "url": "https://www.trykopi.ai/mcp"
     }
   ]
 }

--- a/domains/venturu.com/integrations.json
+++ b/domains/venturu.com/integrations.json
@@ -12,13 +12,6 @@
       "url": "https://venturu.com/mcp"
     },
     {
-      "authStatus": "none",
-      "name": "Venturu MCP server",
-      "slug": "venturu-mcp-server",
-      "type": "mcp",
-      "url": "https://www.venturu.com/mcp"
-    },
-    {
       "authStatus": "required",
       "name": "Venturu Partner API",
       "slug": "venturu-partner-api",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "sync:discovered": "bun scripts/batch/sync-kv.ts",
     "validate-favicons": "bun scripts/validate-favicons.ts",
     "validate:batch": "bun scripts/batch/validate-results.ts",
+    "validate:duplicates": "bun scripts/batch/validate-results.ts --fail-on catalogMismatchedDuplicateLocator,mismatchedDuplicateLocator,duplicateAcrossDomains",
     "dev": "bun run normalize && astro dev",
     "build": "ASTRO_TELEMETRY_DISABLED=1 bun run normalize && ASTRO_TELEMETRY_DISABLED=1 astro build",
     "preview": "astro preview",

--- a/scripts/batch/shared.ts
+++ b/scripts/batch/shared.ts
@@ -6,7 +6,7 @@ import { parse as parseDomain } from "tldts";
 import { DiscoveryResult as DiscoveryResultSchema, type DiscoveryResult } from "../../src/lib/discovery-schema.ts";
 import { assignSlug } from "../../src/lib/discover.ts";
 import { preserveSlugs } from "../../worker/operations.ts";
-import { dedupSurfacesWithReport, type DedupCollapse } from "./dedup.ts";
+import { dedupSurfacesWithReport, type DedupCollapse } from "../../src/lib/dedup.ts";
 
 export const ROOT = new URL("../..", import.meta.url).pathname.replace(/\/$/, "");
 

--- a/scripts/batch/validate-results.ts
+++ b/scripts/batch/validate-results.ts
@@ -2,6 +2,7 @@ import { basename, dirname } from "node:path";
 import { resolve } from "node:path";
 import { getFlag, hasFlag, listJsonFiles, parseArgs, readJson, ROOT, usage } from "./shared.ts";
 import { isSdkNotCli } from "../../src/lib/surface-classify.ts";
+import { surfaceDedupKey } from "../../src/lib/dedup.ts";
 import type { AuthStatus, Credential, StoredDiscovery, Surface } from "../../src/lib/discovery-schema.ts";
 import {
   catalogDomainKey,
@@ -62,6 +63,13 @@ class Report {
 
   get failed(): boolean {
     return [...this.byCheck.values()].some((list) => list.length > 0);
+  }
+
+  /** Whether any of the named checks has findings — for a CI gate that blocks on
+   * a specific failure class (e.g. duplicate surfaces) while leaving unrelated
+   * pre-existing findings non-blocking. */
+  failedOn(checks: readonly string[]): boolean {
+    return checks.some((check) => (this.byCheck.get(check)?.length ?? 0) > 0);
   }
 
   print(maxExamples: number): void {
@@ -208,16 +216,18 @@ function withinDomainDuplicates(domain: string, surfaces: readonly Surface[], re
     }
   }
 
-  // Same locator (url/spec/command), different name — e.g. "Stripe CLI" and
-  // "Stripe MCP" both pointing at the same command/endpoint with mismatched
-  // labels is the reported Stripe CLI/MCP dupe shape when the locator is
-  // actually identical (as opposed to two genuinely distinct surfaces).
+  // Same locator, different name — e.g. "Stripe CLI" and "Stripe MCP" pointing at
+  // the same command/endpoint with mismatched labels, or the same MCP server
+  // listed under both its apex and `mcp.` host (slack.com/mcp vs
+  // mcp.slack.com/mcp). Key on the dedup key so this flags exactly the pairs the
+  // dedup pass would collapse — host-normalized for MCP, spec-normalized for
+  // http/graphql — instead of only exact-string locator matches.
   const byLocator = new Map<string, Surface>();
   for (const surface of surfaces) {
     if (isSdkNotCli(surface)) continue;
     const locator = surfaceLocator(surface);
     if (!locator) continue;
-    const key = `${surface.type}|${locator.trim().toLowerCase()}`;
+    const key = surfaceDedupKey(surface as never);
     const prior = byLocator.get(key);
     if (prior && normName(prior.name) !== normName(surface.name)) {
       report.add(
@@ -335,6 +345,7 @@ async function main(): Promise<void> {
       }
 
       const seenInDomain = new Map<string, CatalogCheckSurface>();
+      const seenByDedupKey = new Map<string, CatalogCheckSurface>();
       for (const s of d.surfaces ?? []) {
         if (isBadPathSegment(s.slug)) {
           report.add("catalogBadSlug", domain, `type=${String(s.type)} name=${JSON.stringify(s.name)} slug=${JSON.stringify(s.slug)}`);
@@ -365,6 +376,19 @@ async function main(): Promise<void> {
         } else {
           seenInDomain.set(surfaceKey, s);
         }
+
+        // Same server, different name — the same MCP endpoint under both its
+        // apex and `mcp.`/`www.` host, or one API under two labels. Key on the
+        // dedup key so this flags exactly what the dedup pass would collapse.
+        if (hasUrl || hasSpec || hasCommand || hasPackages) {
+          const dedupKey = surfaceDedupKey(s as never);
+          const dupPrior = seenByDedupKey.get(dedupKey);
+          if (dupPrior && normName(String(dupPrior.name ?? "")) !== normName(String(s.name ?? ""))) {
+            report.add("catalogMismatchedDuplicateLocator", domain, `type=${type} resolves to the same locator as ${JSON.stringify(dupPrior.name)}: name=${JSON.stringify(s.name)} (slugs: ${String(dupPrior.slug)}, ${String(s.slug)})`);
+          } else if (!dupPrior) {
+            seenByDedupKey.set(dedupKey, s);
+          }
+        }
       }
     }
 
@@ -374,7 +398,12 @@ async function main(): Promise<void> {
   }
 
   report.print(maxExamples);
-  if (report.failed) process.exit(1);
+  // `--fail-on a,b` blocks only on the named checks (a CI gate for one failure
+  // class); without it, any finding fails as before.
+  const failOnFlag = getFlag(args, "fail-on");
+  const failChecks = failOnFlag ? failOnFlag.split(",").map((c) => c.trim()).filter(Boolean) : null;
+  const failed = failChecks ? report.failedOn(failChecks) : report.failed;
+  if (failed) process.exit(1);
 }
 
 await main();

--- a/src/lib/dedup.test.ts
+++ b/src/lib/dedup.test.ts
@@ -94,4 +94,47 @@ describe("dedupSurfaces", () => {
     };
     expect(dedupSurfaces(raw).surfaces).toHaveLength(1);
   });
+
+  test("collapses an apex + dedicated `mcp.` host into one server, keeping the mcp. endpoint", () => {
+    const raw = {
+      domain: "slack.com",
+      surfaces: [
+        { type: "mcp", name: "MCP server", slug: "mcp-server", url: "https://slack.com/mcp", auth: { status: "required", entries: [{ use: [{ id: "slack_oauth", mechanics: { source: "well-known" } }] }] } },
+        { type: "mcp", name: "Slack MCP Server", slug: "slack-mcp-server", url: "https://mcp.slack.com/mcp", auth: { status: "required", entries: [{ use: [{ id: "slack_oauth", mechanics: { source: "well-known" } }] }] } },
+      ],
+    };
+    const { result, collapses } = dedupSurfacesWithReport(raw);
+    expect(result.surfaces).toHaveLength(1);
+    expect(result.surfaces[0]!.url).toBe("https://mcp.slack.com/mcp");
+    expect(collapses).toHaveLength(1);
+  });
+
+  test("collapses a `www.` alias into the apex endpoint", () => {
+    const raw = {
+      domain: "send.co",
+      surfaces: [
+        { type: "mcp", name: "MCP server", url: "https://send.co/mcp", auth: { status: "required", entries: [{ use: [{ id: "send_oauth" }] }] } },
+        { type: "mcp", name: "Send MCP Server", url: "https://www.send.co/mcp", auth: { status: "required", entries: [{ use: [{ id: "send_oauth" }] }] } },
+      ],
+    };
+    const result = dedupSurfaces(raw);
+    expect(result.surfaces).toHaveLength(1);
+    expect(result.surfaces[0]!.url).toBe("https://send.co/mcp");
+  });
+
+  test("keeps genuinely distinct MCP servers on the same domain", () => {
+    const raw = {
+      domain: "webex.com",
+      surfaces: [
+        { type: "mcp", name: "Webex Meetings MCP", url: "https://mcp.webexapis.com/mcp/webex-meeting", auth: { status: "required", entries: [{ use: [{ id: "webex_oauth" }] }] } },
+        { type: "mcp", name: "Webex Messaging MCP", url: "https://mcp.webexapis.com/mcp/webex-messaging", auth: { status: "required", entries: [{ use: [{ id: "webex_oauth" }] }] } },
+      ],
+    };
+    // Distinct paths on one dedicated host stay separate — different servers.
+    expect(dedupSurfaces(raw).surfaces).toHaveLength(2);
+    // core-mcp./metrics-mcp. are non-cosmetic subdomains, not the mcp. label.
+    expect(surfaceDedupKey({ type: "mcp", url: "https://core-mcp.commercelayer.io/mcp" })).not.toBe(
+      surfaceDedupKey({ type: "mcp", url: "https://metrics-mcp.commercelayer.io/mcp" }),
+    );
+  });
 });

--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -41,17 +41,41 @@ export function surfaceDedupKey(surface: SurfaceLike): string {
       ? (surface.command ?? surface.packages?.[0]?.identifier)
       : type === "http" || type === "graphql"
         ? (stripSpecExt(surface.spec) ?? surface.url)
-        : type === "mcp"
-          ? surface.url
-          : undefined;
+        : undefined;
   // Distinct APIs can share one base url (hanko's Public + Flow APIs on the
   // tenant host). A url-only key merges them wrongly — qualify with the name;
   // spec-keyed and name-keyed surfaces keep exact-collision semantics.
   if ((type === "http" || type === "graphql") && !surface.spec && surface.url) {
     return `${type}|${normalizeLocator(surface.url)}|${normalizeLocator(surface.name)}`;
   }
+  // One MCP server is routinely listed under cosmetic host variants — the apex,
+  // a `www.` alias, and the dedicated `mcp.` host all resolve to the SAME server
+  // (slack.com/mcp === mcp.slack.com/mcp). Key on the host-normalized endpoint
+  // so those collapse. Genuinely distinct servers differ by path or a
+  // non-cosmetic subdomain (core-mcp./metrics-mcp.) and keep separate keys.
+  if (type === "mcp") {
+    return `mcp|${normalizeMcpLocator(surface.url) || normalizeLocator(surface.name)}`;
+  }
 
   return `${type}|${normalizeLocator(locator) || normalizeLocator(surface.name)}`;
+}
+
+/** Strip a leading `mcp.`/`www.` host label from an otherwise-normalized MCP
+ * endpoint so cosmetic host variants of one server share a dedup key. */
+function normalizeMcpLocator(url: unknown): string {
+  return normalizeLocator(url).replace(/^(?:mcp|www)\./, "");
+}
+
+/** Rank an MCP surface's host for merge preference: the dedicated `mcp.` host is
+ * the vendor-canonical endpoint, the apex is next, and a `www.` marketing alias
+ * is least preferred. Used only to pick which URL survives a same-server
+ * collapse — auth entries are unioned regardless of which side is kept. */
+function mcpHostRank(surface: SurfaceLike): number {
+  if (surface.type !== "mcp") return 0;
+  const host = normalizeLocator(surface.url).split("/")[0] ?? "";
+  if (host.startsWith("mcp.")) return 2;
+  if (host.startsWith("www.")) return 0;
+  return host ? 1 : 0;
 }
 
 function stripSpecExt(spec: string | null | undefined): string | undefined {
@@ -87,6 +111,12 @@ function populatedCount(value: unknown): number {
 }
 
 function shouldPrefer(candidate: SurfaceLike, current: SurfaceLike): boolean {
+  // For two collapsed MCP variants the URL is the field that matters and auth is
+  // unioned either way, so the canonical host wins before auth/populated-ness.
+  if (candidate.type === "mcp" && current.type === "mcp") {
+    const hostDelta = mcpHostRank(candidate) - mcpHostRank(current);
+    if (hostDelta !== 0) return hostDelta > 0;
+  }
   const rankDelta = authRank(candidate) - authRank(current);
   if (rankDelta !== 0) return rankDelta > 0;
   return populatedCount(candidate) > populatedCount(current);
@@ -174,13 +204,17 @@ function rewriteAuthIds(surface: SurfaceLike, ids: Map<string, string>): void {
   }
 }
 
-export function dedupSurfacesWithReport<T>(result: T, domain = (result as { domain?: string })?.domain ?? "unknown"): { result: T; collapses: DedupCollapse[] } {
-  const next = clone(result) as T & { surfaces?: SurfaceLike[]; credentials?: unknown };
+/** Collapse duplicate surfaces within one discovery result. Pure over the
+ * surface array (no credential reshaping), so both the ingestion path and the
+ * render path can reuse it. */
+export function collapseDuplicateSurfaces(
+  input: readonly SurfaceLike[],
+  domain = "unknown",
+): { surfaces: SurfaceLike[]; collapses: DedupCollapse[] } {
   const collapses: DedupCollapse[] = [];
-  const surfaces = Array.isArray(next.surfaces) ? next.surfaces : [];
   const byKey = new Map<string, number>();
   const deduped: SurfaceLike[] = [];
-  for (const surface of surfaces) {
+  for (const surface of input) {
     const key = surfaceDedupKey(surface);
     const existingIndex = byKey.get(key);
     if (existingIndex === undefined) {
@@ -226,6 +260,24 @@ export function dedupSurfacesWithReport<T>(result: T, domain = (result as { doma
     deduped.splice(i, 1);
     collapses.push({ domain, dropped: String(stub.name ?? "mcp stub"), kept: String(merged.name ?? "mcp") });
   }
+
+  return { surfaces: deduped, collapses };
+}
+
+/** Render-safe surface dedup for a discovery doc: collapse duplicate surfaces
+ * without reshaping credentials. Applied at read time so any duplicate already
+ * stored in KV or a baseline renders as one server. */
+export function dedupeDocSurfaces<T extends { surfaces?: unknown; domain?: unknown }>(doc: T): T {
+  if (!Array.isArray(doc.surfaces)) return doc;
+  const domain = typeof doc.domain === "string" ? doc.domain : "unknown";
+  const { surfaces } = collapseDuplicateSurfaces(doc.surfaces as SurfaceLike[], domain);
+  return { ...doc, surfaces };
+}
+
+export function dedupSurfacesWithReport<T>(result: T, domain = (result as { domain?: string })?.domain ?? "unknown"): { result: T; collapses: DedupCollapse[] } {
+  const next = clone(result) as T & { surfaces?: SurfaceLike[]; credentials?: unknown };
+  const surfaces = Array.isArray(next.surfaces) ? next.surfaces : [];
+  const { surfaces: deduped, collapses } = collapseDuplicateSurfaces(surfaces, domain);
 
   const idRewrite = new Map<string, string>();
   const credentials: CredentialLike[] = [];

--- a/src/pages/[domain]/[surface].astro
+++ b/src/pages/[domain]/[surface].astro
@@ -14,6 +14,7 @@ import Setup from "~/components/surface/Setup.tsx";
 import { aliasesOf, canonicalDomain } from "~/lib/domain-aliases.ts";
 import { faviconFor, isJunkDomain } from "~/lib/favicon.ts";
 import { isSdkNotCli } from "~/lib/surface-classify.ts";
+import { dedupeDocSurfaces } from "~/lib/dedup.ts";
 import {
   SURFACE_TYPE_LABEL,
   cliLoginFor,
@@ -39,8 +40,11 @@ const looksLikeDomain = domain.includes(".");
 
 // Slugs are server-assigned identity (v3) — match directly. A client SDK/library
 // mis-typed as `cli` is not a surface, so its slug resolves to nothing → 404.
+// Collapse duplicate surfaces first so a dropped duplicate's slug (e.g. an MCP
+// server's non-canonical host variant) resolves to nothing → 404, matching the
+// deduped domain page.
 const find = (doc?: DiscoveryDoc | null) =>
-  (doc?.surfaces ?? []).find((s) => s.slug === slug && !isSdkNotCli(s));
+  ((doc?.surfaces ? dedupeDocSurfaces(doc).surfaces : []) ?? []).find((s) => s.slug === slug && !isSdkNotCli(s));
 
 let surface: Surface | undefined;
 let creds: Record<string, Credential> = {};

--- a/src/pages/ssr/[domain].astro
+++ b/src/pages/ssr/[domain].astro
@@ -9,6 +9,7 @@
 // component renders both, so nothing can drift.
 import DomainPage from "~/components/DomainPage.astro";
 import { aliasesOf, canonicalDomain } from "~/lib/domain-aliases.ts";
+import { dedupeDocSurfaces } from "~/lib/dedup.ts";
 import type { DiscoverData } from "~/lib/surface-sections.ts";
 
 export const prerender = false;
@@ -48,6 +49,11 @@ if (!initialData && runtime) {
 
 // No KV and no baseline discovery surfaces → true 404.
 if (!initialData) return new Response(null, { status: 404 });
+
+// Collapse duplicate surfaces (e.g. one MCP server listed under both its apex
+// and `mcp.` host) so a stale KV row renders one server — matching the deduped
+// island API and surface-detail pages.
+initialData = dedupeDocSurfaces(initialData);
 
 Astro.response.headers.set("cache-control", "public, max-age=60");
 ---

--- a/worker/discovery-doc.ts
+++ b/worker/discovery-doc.ts
@@ -2,6 +2,7 @@ import type { Env } from "./env.ts";
 import type { DiscoverData } from "../src/lib/surface-sections.ts";
 import { aliasesOf, canonicalDomain } from "../src/lib/domain-aliases.ts";
 import { isSdkNotCli } from "../src/lib/surface-classify.ts";
+import { dedupeDocSurfaces } from "../src/lib/dedup.ts";
 
 export async function discoveryKvGet(env: Env, domain: string): Promise<string | null> {
   const canonical = canonicalDomain(domain);
@@ -28,6 +29,12 @@ const stripSdkSurfaces = (doc: DiscoveryDocWithSurfaces): DiscoveryDocWithSurfac
   surfaces: doc.surfaces.filter((s) => !isSdkNotCli(s)),
 });
 
+/** Read-time cleanup shared by every render source: drop SDK-as-CLI surfaces,
+ * then collapse duplicate surfaces (e.g. one MCP server listed under both its
+ * apex and `mcp.` host) so a stale KV row or baseline never renders twice. */
+const cleanSurfaces = (doc: DiscoveryDocWithSurfaces): DiscoveryDocWithSurfaces =>
+  dedupeDocSurfaces(stripSdkSurfaces(doc));
+
 /** The domain page's render source: durable discovery result first, then the
  * prerendered baseline discovery JSON. */
 export async function discoveryDoc(env: Env, origin: string, domain: string): Promise<DiscoverData | null> {
@@ -37,13 +44,13 @@ export async function discoveryDoc(env: Env, origin: string, domain: string): Pr
     if (raw) {
       const stored = JSON.parse(raw) as { result?: DiscoverData; discoveredAt?: string };
       if (hasSurfaceArray(stored.result)) {
-        return stripSdkSurfaces({ ...stored.result, discoveredAt: stored.result.discoveredAt ?? stored.discoveredAt });
+        return cleanSurfaces({ ...stored.result, discoveredAt: stored.result.discoveredAt ?? stored.discoveredAt });
       }
     }
     const res = await env.ASSETS.fetch(`${origin}/disc/${encodeURIComponent(canonical)}.json`);
     if (res.ok) {
       const baseline = (await res.json()) as DiscoverData;
-      if (hasSurfaceArray(baseline)) return stripSdkSurfaces(baseline);
+      if (hasSurfaceArray(baseline)) return cleanSurfaces(baseline);
     }
   } catch {
     /* unavailable or malformed discovery data */

--- a/worker/entry.ts
+++ b/worker/entry.ts
@@ -23,6 +23,7 @@ import { contextWeb, naiveWeb } from "../src/lib/contextdev.ts";
 import { DOMAIN_ALIASES, canonicalDomain } from "../src/lib/domain-aliases.ts";
 import { isJunkDomain, registrableDomain } from "../src/lib/favicon.ts";
 import { isSdkNotCli } from "../src/lib/surface-classify.ts";
+import { collapseDuplicateSurfaces } from "../src/lib/dedup.ts";
 import { renderOgPng, type OgFonts, type OgImageData } from "../src/lib/og.tsx";
 import type { Surface } from "../src/lib/surface-view.ts";
 import type { Credential } from "../src/lib/surface-view.ts";
@@ -281,9 +282,13 @@ function discoveryCounts(result: {
  * value unchanged if it doesn't parse into the expected shape. */
 function stripSdkFromStored(raw: string): string {
   try {
-    const envelope = JSON.parse(raw) as { result?: { surfaces?: Surface[] } };
+    const envelope = JSON.parse(raw) as { result?: { surfaces?: Surface[]; domain?: string } };
     if (envelope.result?.surfaces?.length) {
-      envelope.result.surfaces = envelope.result.surfaces.filter((s) => !isSdkNotCli(s));
+      // Match what the pages render: drop SDK-as-CLI surfaces, then collapse
+      // duplicate surfaces (e.g. one MCP server under both its apex and `mcp.`
+      // host) so the island's client render agrees with the deduped SSR.
+      const stripped = envelope.result.surfaces.filter((s) => !isSdkNotCli(s));
+      envelope.result.surfaces = collapseDuplicateSurfaces(stripped as never, envelope.result.domain ?? "unknown").surfaces as unknown as Surface[];
       return JSON.stringify(envelope);
     }
   } catch {


### PR DESCRIPTION
The Slack page listed its MCP server twice — `slack.com/mcp` and `mcp.slack.com/mcp` — because discovery found the same server under two hosts and the surface dedup keyed MCP on the raw URL, so the host-only difference never collapsed. Nine domains had the same shape (apex vs `mcp.`, or apex vs `www.`).

What changed:

- Dedup key normalizes the MCP host (strips a leading `mcp.`/`www.` label) and prefers the canonical host (`mcp.` > apex > `www.`) when merging. Ingestion now collapses these before they reach KV.
- Every render source dedups on read (domain SSR, the island's discovery API, surface detail pages, OG), so an already-stored duplicate renders as one server without a re-sync.
- The nine affected domain files are cleaned.
- The validator flags the same-server/different-name case, and a scoped CI check blocks a PR that reintroduces it (the 700+ unrelated pre-existing findings stay non-blocking).
- The shared dedup module moves to `src/lib` so the worker and pages import it without reaching into `scripts/`.

Verified locally by seeding KV with the pre-fix Slack row: the domain page, discovery API, and detail pages all render the single `mcp.slack.com/mcp` server; the dropped duplicate's detail page 404s. 163 domains have more than one MCP surface but only these 9 collapse under the normalization — genuinely distinct servers (webex's four, etc.) are untouched.