### PR TITLE
Harden the discovery agent

### DIFF
--- a/src/lib/catalog-seed.ts
+++ b/src/lib/catalog-seed.ts
@@ -1,7 +1,7 @@
 import catalogSeedJson from "../../output/catalog-seeds.json";
 import type { Feed, Kind } from "./types.ts";
 
-interface CatalogSeedEntry {
+export interface CatalogSeedEntry {
   kind: Kind;
   name: string;
   feeds: Feed[];
@@ -17,15 +17,24 @@ interface CatalogSeedEntry {
   repo?: string;
 }
 
-const catalogSeedData = catalogSeedJson as Record<string, CatalogSeedEntry[]>;
+let catalogSeedData = catalogSeedJson as Record<string, CatalogSeedEntry[]>;
+
+export function setCatalogSeedDataForTest(data: Record<string, CatalogSeedEntry[]> | null): void {
+  catalogSeedData = data ?? (catalogSeedJson as Record<string, CatalogSeedEntry[]>);
+}
+
+export function catalogSeedRecords(domain: string): CatalogSeedEntry[] {
+  const target = domain.trim().toLowerCase();
+  if (!target) return [];
+  return (catalogSeedData[target] ?? []).filter((record) => !record.feeds.includes("discovered"));
+}
 
 export function catalogSeeds(domain: string): string[] {
   const target = domain.trim().toLowerCase();
   if (!target) return [];
 
   const facts: string[] = [];
-  for (const record of catalogSeedData[target] ?? []) {
-    if (record.feeds.includes("discovered")) continue;
+  for (const record of catalogSeedRecords(target)) {
     const fact = seedFor(record);
     if (fact) facts.push(fact);
   }

--- a/src/lib/discover.test.ts
+++ b/src/lib/discover.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { PROBE_KEYS } from "./conventions.ts";
 import { discover, slackMcpAppManifestUrl, type ChatFn, type WebBackend } from "./discover.ts";
+import { setCatalogSeedDataForTest } from "./catalog-seed.ts";
 import type { DetectionResult } from "./detect.ts";
 
 const web: WebBackend = {
@@ -187,5 +188,110 @@ describe("discover MCP onboarding overrides", () => {
     expect(setup).toContain("pre-registered app required");
     expect(setup).not.toContain("Slack MCP server access");
     expect(setup).not.toContain("api.slack.com/apps?new_app=1");
+  });
+});
+
+describe("discover completion behavior", () => {
+  test("propagates a chat failure instead of returning an empty success", async () => {
+    const chat: ChatFn = async () => {
+      throw new Error("model crashed");
+    };
+
+    await expect(discover("example.com", { ...baseDetection(""), found: [], probed: [], llmsTxt: undefined }, chat, web)).rejects.toThrow("model crashed");
+  });
+
+  test("keeps a completed zero-surface run as a valid success", async () => {
+    const chat: ChatFn = async () => ({
+      message: { role: "assistant", content: null },
+      toolCalls: [
+        {
+          id: "finish-1",
+          name: "finish",
+          arguments: {
+            summary: "No public developer integration surfaces were found.",
+            description: "Example is a test service.",
+          },
+        },
+      ],
+    });
+
+    const result = await discover("example.com", { ...baseDetection(""), found: [], probed: [], llmsTxt: undefined }, chat, web);
+
+    expect(result?.surfaces).toEqual([]);
+    expect(result?.summary).toBe("No public developer integration surfaces were found.");
+  });
+});
+
+describe("discover catalog seed merge", () => {
+  test("appends a registry seed when the model records nothing", async () => {
+    setCatalogSeedDataForTest({
+      "seeded.test": [
+        {
+          kind: "openapi",
+          name: "Seeded REST API",
+          feeds: ["apis-guru"],
+          specUrl: "https://api.seeded.test/openapi.json",
+          docsUrl: "https://docs.seeded.test/api",
+        },
+      ],
+    });
+    const chat: ChatFn = async () => ({
+      message: { role: "assistant", content: null },
+      toolCalls: [{ id: "finish-1", name: "finish", arguments: { summary: "", description: "Seeded service." } }],
+    });
+
+    try {
+      const result = await discover("seeded.test", { domain: "seeded.test", found: [], probed: [], mcp: [], errors: [] }, chat, web);
+
+      expect(result?.surfaces).toHaveLength(1);
+      expect(result?.surfaces[0]).toMatchObject({
+        slug: "seeded-rest-api",
+        name: "Seeded REST API",
+        type: "http",
+        spec: "https://api.seeded.test/openapi.json",
+        basis: { via: "detected", signal: "registry" },
+        auth: { status: "unknown" },
+      });
+    } finally {
+      setCatalogSeedDataForTest(null);
+    }
+  });
+
+  test("does not append a duplicate when a model surface matches the seed locator", async () => {
+    setCatalogSeedDataForTest({
+      "seeded.test": [
+        {
+          kind: "openapi",
+          name: "Seeded REST API",
+          feeds: ["apis-guru"],
+          specUrl: "https://api.seeded.test/openapi.json",
+        },
+      ],
+    });
+    const chat: ChatFn = async () => ({
+      message: { role: "assistant", content: null },
+      toolCalls: [
+        {
+          id: "surface-1",
+          name: "record_surface",
+          arguments: {
+            name: "Enriched REST API",
+            type: "http",
+            url: "https://api.seeded.test/openapi.json",
+            authStatus: "unknown",
+          },
+        },
+        { id: "finish-1", name: "finish", arguments: { summary: "REST API.", description: "Seeded service." } },
+      ],
+    });
+
+    try {
+      const result = await discover("seeded.test", { domain: "seeded.test", found: [], probed: [], mcp: [], errors: [] }, chat, web);
+
+      expect(result?.surfaces).toHaveLength(1);
+      expect(result?.surfaces[0]?.name).toBe("Enriched REST API");
+    } finally {
+      setCatalogSeedDataForTest(null);
+    }
   });
 });

--- a/src/lib/discover.ts
+++ b/src/lib/discover.ts
@@ -29,7 +29,7 @@
  */
 import type { DetectionResult, McpDetection } from "./detect.ts";
 import { probeMcpOnboarding } from "./detect.ts";
-import { catalogSeeds } from "./catalog-seed.ts";
+import { catalogSeedRecords, catalogSeeds, type CatalogSeedEntry } from "./catalog-seed.ts";
 import { validateSpecUrl, type SpecValidationResult } from "./spec-validate.ts";
 
 export const SLACK_MCP_USER_SCOPES = [
@@ -741,6 +741,11 @@ function surfaceLocator(s: Surface): string {
   return `${s.type}|${(s.spec || s.url || s.command || packageId || s.name).toLowerCase()}`;
 }
 
+function surfaceLocatorCandidates(s: Surface): string[] {
+  const locators = [s.spec, s.url, s.command, s.packages?.[0]?.identifier].filter((v): v is string => !!v);
+  return locators.length ? locators.map((locator) => `${s.type}|${locator.toLowerCase()}`) : [surfaceLocator(s)];
+}
+
 function entryKey(entry: AuthEntry): string {
   return entry.use
     .map((use) => `${use.id}:${JSON.stringify(use.mechanics)}`)
@@ -826,6 +831,52 @@ function mergeDeclared(r: DiscoveryResult, detect: DetectionResult, emit?: Emit)
     r.surfaces.push(surface);
     byLocator.set(surfaceLocator(surface), surface);
     emit?.({ kind: "surface", surface });
+  }
+}
+
+function mergeCatalogSeeds(r: DiscoveryResult, detect: DetectionResult, emit?: Emit): void {
+  const byLocator = new Map<string, Surface>();
+  for (const surface of r.surfaces) {
+    for (const locator of surfaceLocatorCandidates(surface)) byLocator.set(locator, surface);
+  }
+
+  for (const record of catalogSeedRecords(detect.domain)) {
+    const surface = catalogSeedToSurface(record);
+    if (!surface) continue;
+    if (surfaceLocatorCandidates(surface).some((locator) => byLocator.has(locator))) continue;
+    surface.slug = assignSlug(surface.name || "Registry surface", r.surfaces);
+    r.surfaces.push(surface);
+    for (const locator of surfaceLocatorCandidates(surface)) byLocator.set(locator, surface);
+    emit?.({ kind: "surface", surface });
+  }
+}
+
+function isAuthlessSeed(record: CatalogSeedEntry): boolean {
+  return record.authTypes?.some((type) => type.toLowerCase() === "none" || type.toLowerCase() === "authless") ?? false;
+}
+
+function catalogSeedToSurface(record: CatalogSeedEntry): Surface | null {
+  const basis: Basis = { via: "detected", signal: "registry" };
+  const auth: AuthStatus = isAuthlessSeed(record) ? { status: "none", basis } : { status: "unknown" };
+  switch (record.kind) {
+    case "mcp":
+      return record.remoteUrl
+        ? { slug: "", name: record.name, type: "mcp", docs: record.docsUrl ?? record.docs, basis, url: record.remoteUrl, transports: record.transport ? [record.transport] : undefined, auth }
+        : null;
+    case "openapi":
+      return record.specUrl
+        ? { slug: "", name: record.name, type: "http", docs: record.docsUrl ?? record.docs, basis, spec: record.specUrl, auth }
+        : null;
+    case "graphql":
+      return record.endpoint
+        ? { slug: "", name: record.name, type: "graphql", docs: record.docsUrl ?? record.docs, basis, url: record.endpoint, auth }
+        : null;
+    case "cli":
+      return record.command
+        ? { slug: "", name: record.name, type: "cli", docs: record.docs ?? record.docsUrl, basis, command: record.command, notes: record.install, auth }
+        : null;
+    default:
+      return null;
   }
 }
 
@@ -946,6 +997,7 @@ function merge(r: DiscoveryResult, detect: DetectionResult, emit?: Emit): Discov
   }
 
   mergeDeclared(r, detect, emit);
+  mergeCatalogSeeds(r, detect, emit);
 
   if (!r.summary && r.surfaces.length) {
     r.summary = `Exposes ${[...new Set(r.surfaces.map((s) => s.type))].join(", ")} for this service.`;

--- a/src/lib/favicon.ts
+++ b/src/lib/favicon.ts
@@ -1,6 +1,6 @@
 import { parse } from "tldts";
 
-const JUNK_TLDS = new Set(["local", "test", "internal", "example"]);
+const JUNK_TLDS = new Set(["local", "test", "internal", "example", "invalid", "localhost"]);
 const JUNK_HOSTING_SUFFIXES = [
   "workers.dev",
   "awsapprunner.com",
@@ -80,6 +80,7 @@ export function isJunkDomain(domain: string | null | undefined): boolean {
   const labels = host.split(".").filter(Boolean);
   const tld = labels[labels.length - 1];
   if (tld && JUNK_TLDS.has(tld)) return true;
+  if (host === "localhost" || labels[0] === "example") return true;
   if (JUNK_HOSTING_SUFFIXES.some((suffix) => host === suffix || host.endsWith(`.${suffix}`))) return true;
 
   const info = parse(host, { allowPrivateDomains: true });

--- a/worker/api.ts
+++ b/worker/api.ts
@@ -13,6 +13,7 @@ import { Credential, DISCOVERY_VERSION, Surface } from "../src/lib/discovery-sch
 import { canonicalDomain } from "../src/lib/domain-aliases.ts";
 import { searchIndex } from "../src/lib/search-index.ts";
 import type { Env } from "./env.ts";
+import { validateDiscoverableDomain } from "./domain-validation.ts";
 import { discoveryDoc } from "./discovery-doc.ts";
 import { appendLiveSearchResults, readLiveIndex, type LiveIndexEntry } from "./live-index.ts";
 import {
@@ -62,6 +63,10 @@ const SearchResults = Schema.Struct({
 const SurfaceNotFound = Schema.Struct({
   error: Schema.String.annotate({ description: "Surface document lookup failure." }),
 }).pipe(HttpApiSchema.status(404)).annotate({ description: "No stored or baseline surface document exists for the domain." });
+
+const InvalidDomain = Schema.Struct({
+  error: Schema.String.annotate({ description: "Domain validation failure." }),
+}).pipe(HttpApiSchema.status(400)).annotate({ description: "The supplied domain is not a public discoverable domain." });
 
 const SurfaceResult = Schema.Struct({
   version: Schema.Literal(DISCOVERY_VERSION),
@@ -118,6 +123,7 @@ const Search = HttpApiEndpoint.get("search", "/api/search", {
 const Detect = HttpApiEndpoint.get("detect", "/api/:domain/detect", {
   params: DetectParams,
   success: DetectionResult,
+  error: InvalidDomain,
 })
   .annotate(OpenApi.Summary, "Detect a domain's agent-readiness")
   .annotate(OpenApi.Description, DETECT_DESCRIPTION);
@@ -125,6 +131,7 @@ const Detect = HttpApiEndpoint.get("detect", "/api/:domain/detect", {
 const Discover = HttpApiEndpoint.get("discover", "/api/:domain/discover", {
   params: DiscoverParams,
   success: DiscoverResult,
+  error: InvalidDomain,
 })
   .annotate(OpenApi.Summary, "Discover how to authenticate with a domain's API")
   .annotate(OpenApi.Description, DISCOVER_DESCRIPTION);
@@ -178,8 +185,14 @@ const DetectGroup = HttpApiBuilder.group(Api, "detect", (handlers) =>
         const liveEntries = yield* Effect.promise(() => readLiveIndex(env));
         return searchCatalog(req.query, liveEntries);
       }))
-    .handle("detect", (req: { readonly params: { readonly domain: string } }) => runDetect(canonicalDomain(req.params.domain)))
-    .handle("discover", (req: { readonly params: { readonly domain: string } }) => runDiscover(canonicalDomain(req.params.domain)))
+    .handle("detect", (req: { readonly params: { readonly domain: string } }) => {
+      const validation = validateDiscoverableDomain(req.params.domain);
+      return "error" in validation ? Effect.fail(validation as typeof InvalidDomain.Type) : runDetect(validation.domain);
+    })
+    .handle("discover", (req: { readonly params: { readonly domain: string } }) => {
+      const validation = validateDiscoverableDomain(req.params.domain);
+      return "error" in validation ? Effect.fail(validation as typeof InvalidDomain.Type) : runDiscover(validation.domain);
+    })
     .handle("surface", (req: { readonly params: { readonly domain: string } }) =>
       Effect.gen(function*() {
         const { env, origin } = yield* ApiRuntime;

--- a/worker/domain-validation.test.ts
+++ b/worker/domain-validation.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { validateDiscoverableDomain } from "./domain-validation.ts";
+
+describe("validateDiscoverableDomain", () => {
+  test("rejects invalid, path, filename-style, and reserved domains", () => {
+    for (const input of ["publishing.md", "llms-full.txt", "eva.ac%2Fhello", "example.com", "example.io", "localhost"]) {
+      expect(validateDiscoverableDomain(input)).toEqual({ error: "not a public registrable domain" });
+    }
+  });
+
+  test("accepts real domains and subdomain inputs", () => {
+    expect(validateDiscoverableDomain("stripe.com")).toEqual({ domain: "stripe.com" });
+    expect(validateDiscoverableDomain("music.youtube.com")).toEqual({ domain: "music.youtube.com" });
+    expect(validateDiscoverableDomain("x.com")).toEqual({ domain: "x.com" });
+  });
+});

--- a/worker/domain-validation.ts
+++ b/worker/domain-validation.ts
@@ -1,0 +1,22 @@
+import { canonicalDomain } from "../src/lib/domain-aliases.ts";
+import { isJunkDomain, registrableDomain } from "../src/lib/favicon.ts";
+
+export interface ValidDomain {
+  domain: string;
+}
+
+export function validateDiscoverableDomain(input: string): ValidDomain | { error: string } {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(input).trim().toLowerCase();
+  } catch {
+    return { error: "not a public registrable domain" };
+  }
+  if (!decoded || decoded.includes("/")) return { error: "not a public registrable domain" };
+  if (decoded === "publishing.md") return { error: "not a public registrable domain" };
+
+  const canonical = canonicalDomain(decoded);
+  const registrable = registrableDomain(canonical);
+  if (!registrable || isJunkDomain(canonical)) return { error: "not a public registrable domain" };
+  return { domain: canonical };
+}

--- a/worker/domain-validation.ts
+++ b/worker/domain-validation.ts
@@ -5,6 +5,11 @@ export interface ValidDomain {
   domain: string;
 }
 
+// The site's own root-level file pages whose names parse as valid domains
+// (.md is Moldova's TLD). A crawler hitting /publishing.md lands here as a
+// "domain" — these are paths, not services.
+const SITE_FILE_PATHS = new Set(["publishing.md", "skill.md", "claude.md", "agents.md", "readme.md"]);
+
 export function validateDiscoverableDomain(input: string): ValidDomain | { error: string } {
   let decoded: string;
   try {
@@ -13,7 +18,7 @@ export function validateDiscoverableDomain(input: string): ValidDomain | { error
     return { error: "not a public registrable domain" };
   }
   if (!decoded || decoded.includes("/")) return { error: "not a public registrable domain" };
-  if (decoded === "publishing.md") return { error: "not a public registrable domain" };
+  if (SITE_FILE_PATHS.has(decoded)) return { error: "not a public registrable domain" };
 
   const canonical = canonicalDomain(decoded);
   const registrable = registrableDomain(canonical);

--- a/worker/entry.ts
+++ b/worker/entry.ts
@@ -27,6 +27,7 @@ import { renderOgPng, type OgFonts, type OgImageData } from "../src/lib/og.tsx";
 import type { Surface } from "../src/lib/surface-view.ts";
 import type { Credential } from "../src/lib/surface-view.ts";
 import type { EdgeCaches, Env, ExecutionContext } from "./env.ts";
+import { validateDiscoverableDomain } from "./domain-validation.ts";
 import { McpDurableObject } from "./mcp-do.ts";
 
 // Bump when detect/discover output shape or logic changes, so the edge Cache API
@@ -574,7 +575,9 @@ async function handleRequest(
     // instantly; a cold run streams real progress and warms the cache.
     const streamMatch = /^\/api\/([^/]+)\/discover\/stream\/?$/.exec(url.pathname);
     if (streamMatch) {
-      const domain = canonicalDomain(decodeURIComponent(streamMatch[1]));
+      const validation = validateDiscoverableDomain(streamMatch[1]);
+      if ("error" in validation) return json({ error: validation.error }, 400);
+      const domain = validation.domain;
       // `force=1` (the regenerate button) skips the cached result and re-runs
       // discovery; the fresh run then overwrites the cache entry below.
       const force = url.searchParams.get("force") === "1";
@@ -668,6 +671,14 @@ async function handleRequest(
       /^\/api\/[^/]+\/(?:detect|discover|surface)\/?$/.test(url.pathname)
     ) {
       const endpoint = apiEndpoint(url.pathname);
+      const domainMatch = /^\/api\/([^/]+)\/(?:detect|discover)\/?$/.exec(url.pathname);
+      if (domainMatch) {
+        const validation = validateDiscoverableDomain(domainMatch[1]);
+        if ("error" in validation) {
+          track(env, ctx, request, "api_request", { ...(endpoint && { endpoint }), cache_hit: false, status: 400 });
+          return json({ error: validation.error }, 400);
+        }
+      }
       const cache = (caches as unknown as EdgeCaches).default;
       // Version the cache key so a deploy that bumps CACHE_VERSION orphans stale
       // entries (the Cache API otherwise survives deploys).

--- a/worker/operations.test.ts
+++ b/worker/operations.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { discoverWithProgress, runDiscover, setChat, setWebBackend, type ChatFn } from "./operations.ts";
+
+const originalFetch = globalThis.fetch;
+
+function stubDetectFetch(): void {
+  globalThis.fetch = (async () => new Response("not found", { status: 404, headers: { "content-type": "text/plain" } })) as typeof fetch;
+}
+
+const web = {
+  canSearch: true,
+  search: async () => [],
+  scrape: async () => "",
+  sitemap: async () => [],
+};
+
+afterEach(() => {
+  setChat(null);
+  setWebBackend(web);
+  globalThis.fetch = originalFetch;
+});
+
+describe("discovery operations", () => {
+  test("runDiscover fails when the agent throws", async () => {
+    stubDetectFetch();
+    setWebBackend(web);
+    setChat(async () => {
+      throw new Error("model crashed");
+    });
+
+    await expect(Effect.runPromise(runDiscover("stripe.com"))).rejects.toThrow("model crashed");
+  });
+
+  test("discoverWithProgress fails when the agent throws", async () => {
+    stubDetectFetch();
+    setWebBackend(web);
+    setChat(async () => {
+      throw new Error("model crashed");
+    });
+
+    await expect(discoverWithProgress("stripe.com", () => {})).rejects.toThrow("model crashed");
+  });
+
+  test("runDiscover preserves a completed zero-surface result", async () => {
+    stubDetectFetch();
+    setWebBackend(web);
+    const chat: ChatFn = async () => ({
+      message: { role: "assistant", content: null },
+      toolCalls: [
+        {
+          id: "finish-1",
+          name: "finish",
+          arguments: {
+            summary: "No public developer integration surfaces were found.",
+            description: "Stripe is a payments platform.",
+          },
+        },
+      ],
+    });
+    setChat(chat);
+
+    const result = await Effect.runPromise(runDiscover("empty-run-test.com"));
+
+    expect(result.usedLlm).toBe(true);
+    expect(result.surfaces).toEqual([]);
+    expect(result.summary).toBe("No public developer integration surfaces were found.");
+  });
+});

--- a/worker/operations.ts
+++ b/worker/operations.ts
@@ -162,7 +162,7 @@ export const runDiscover = (domain: string): Effect.Effect<typeof DiscoverResult
   Effect.promise(async () => {
     const d = await detect(canonicalDomain(domain));
     if (!chatFn) return packDiscovery(d.domain, d, null, false);
-    const disc = await discover(d.domain, d, chatFn, webBackend ?? naiveWeb()).catch(() => null);
+    const disc = await discover(d.domain, d, chatFn, webBackend ?? naiveWeb());
     return packDiscovery(d.domain, d, disc, true);
   });
 
@@ -178,6 +178,6 @@ export const discoverWithProgress = async (
   const d = await detect(canonicalDomain(domain));
   emit({ kind: "progress", message: d.found.length ? `Detected: ${d.found.join(", ")}` : "No standard signals — searching" });
   if (!chatFn) return packDiscovery(d.domain, d, null, false);
-  const disc = await discover(d.domain, d, chatFn, webBackend ?? naiveWeb(), emit).catch(() => null);
+  const disc = await discover(d.domain, d, chatFn, webBackend ?? naiveWeb(), emit);
   return packDiscovery(d.domain, d, disc, true);
 };


### PR DESCRIPTION
Three fixes to discovery quality:

- A crashed agent run no longer persists and caches as an empty successful result (stripe.com sat empty in KV for a day this way). Failures now hit the SSE error path and the discovery_error event actually fires.
- Detect/discover endpoints validate the domain before the rate limiter and the LLM run — file-path lookalikes (publishing.md), URL-encoded paths, and reserved names get a 400 instead of a model run.
- Catalog seeds are now merged into results deterministically after the run, the same way detect signals are, so curated registry facts (e.g. the Cloudflare REST API spec) can no longer be dropped by the model.