### PR TITLE
curated: add WebAbility (accessibility MCP)

### DIFF
--- a/curated/webability.json
+++ b/curated/webability.json
@@ -1,0 +1,64 @@
+{
+  "slug": "webability",
+  "name": "WebAbility",
+  "tagline": "Find and fix web accessibility (WCAG) issues from your coding agent.",
+  "description": "WebAbility's MCP server runs WCAG / ADA / Section 508 accessibility scans on any URL or HTML, generates framework-aware fixes (Tailwind, MUI, Bootstrap, WordPress, Next.js), and — uniquely — verifies that a fix actually resolved the issue. It also offers a vision pass that catches focus, icon-contrast and looks-like-a-button issues DOM scanners miss, and a full audit that produces a downloadable report plus an Excel workbook. The DOM-based scan and fix tools run locally with no account.",
+  "domain": "webability.io",
+  "icon": "https://www.google.com/s2/favicons?domain=webability.io&sz=64",
+  "categories": [
+    "accessibility",
+    "developer-tools",
+    "testing"
+  ],
+  "auth": {
+    "methods": [
+      {
+        "type": "none",
+        "label": "No account (local scans)",
+        "note": "scan_page, verify_fix, check_color_contrast, generate_ai_fix and the other DOM-based tools run locally with no credentials."
+      },
+      {
+        "type": "token",
+        "label": "WebAbility account token",
+        "note": "The paid, server-side tools — visual_audit (vision), start_audit and get_audit — need a token from `webability login` or the WEBABILITY_API_KEY env var."
+      }
+    ],
+    "guide": "Install the server:\n\n```bash\nnpm install -g @webability/mcp\n```\n\nAdd it to your IDE (Cursor / Claude Code / GitHub Copilot / Windsurf / VS Code):\n\n```json\n{\n  \"mcpServers\": {\n    \"webability\": { \"command\": \"webability-mcp\" }\n  }\n}\n```\n\nThe DOM-based tools (`scan_page`, `verify_fix`, `check_color_contrast`, `generate_ai_fix`, …) run **locally and need no account**. The paid, server-side tools — `visual_audit` (Claude vision), `start_audit` / `get_audit` (full report + Excel workbook) — require a WebAbility account: run `webability login` (device flow) or set `WEBABILITY_API_KEY`. A hosted server is also available at `https://mcp.webability.io`.",
+    "sources": [
+      {
+        "title": "@webability/mcp on npm",
+        "url": "https://www.npmjs.com/package/@webability/mcp"
+      },
+      {
+        "title": "WebAbility MCP — source & README",
+        "url": "https://github.com/snayyar00/abilyo"
+      }
+    ],
+    "generatedAt": "2026-07-11",
+    "verified": false
+  },
+  "interfaces": [
+    {
+      "format": "mcp",
+      "name": "WebAbility MCP (stdio)",
+      "auth": "mixed",
+      "install": "npm install -g @webability/mcp",
+      "docs": "https://github.com/snayyar00/abilyo",
+      "note": "Local stdio server (bin: webability-mcp). DOM scan/fix tools need no auth; visual_audit and start_audit/get_audit need `webability login` or WEBABILITY_API_KEY.",
+      "origin": "vendor"
+    },
+    {
+      "format": "mcp",
+      "name": "WebAbility MCP (hosted)",
+      "endpoint": "https://mcp.webability.io",
+      "auth": "mixed",
+      "docs": "https://github.com/snayyar00/abilyo",
+      "note": "Hosted streamable-HTTP endpoint; same tools as the stdio server.",
+      "origin": "vendor"
+    }
+  ],
+  "links": {
+    "homepage": "https://webability.io",
+    "docs": "https://github.com/snayyar00/abilyo"
+  }
+}

--- a/curated/webability.json
+++ b/curated/webability.json
@@ -31,7 +31,7 @@
       },
       {
         "title": "WebAbility MCP — source & README",
-        "url": "https://github.com/snayyar00/abilyo"
+        "url": "https://github.com/snayyar00/webability-mcp"
       }
     ],
     "generatedAt": "2026-07-11",
@@ -43,7 +43,7 @@
       "name": "WebAbility MCP (stdio)",
       "auth": "mixed",
       "install": "npm install -g @webability/mcp",
-      "docs": "https://github.com/snayyar00/abilyo",
+      "docs": "https://github.com/snayyar00/webability-mcp",
       "note": "Local stdio server (bin: webability-mcp). DOM scan/fix tools need no auth; visual_audit and start_audit/get_audit need `webability login` or WEBABILITY_API_KEY.",
       "origin": "vendor"
     },
@@ -52,13 +52,13 @@
       "name": "WebAbility MCP (hosted)",
       "endpoint": "https://mcp.webability.io",
       "auth": "mixed",
-      "docs": "https://github.com/snayyar00/abilyo",
+      "docs": "https://github.com/snayyar00/webability-mcp",
       "note": "Hosted streamable-HTTP endpoint; same tools as the stdio server.",
       "origin": "vendor"
     }
   ],
   "links": {
     "homepage": "https://webability.io",
-    "docs": "https://github.com/snayyar00/abilyo"
+    "docs": "https://github.com/snayyar00/webability-mcp"
   }
 }


### PR DESCRIPTION
Adds `curated/webability.json` — **WebAbility**, an accessibility MCP server for AI coding agents (Cursor, Claude Code, Copilot, Windsurf, VS Code).

**What agents can do with it:**
- `scan_page` / `scan_html` / `flow_scan` — WCAG / ADA / Section 508 scans (axe-core + WebAbility detectors + HTML_CodeSniffer), **free and local, no account**
- `generate_ai_fix` — framework-aware fixes (Tailwind, MUI, Bootstrap, WordPress, Next.js)
- `verify_fix` — re-scan a fixed element and confirm the violation is gone (`verified: true/false`)
- `visual_audit` — Claude-vision pass for focus visibility, icon contrast, "looks like a button" (account-gated)
- `start_audit` / `get_audit` — full audit deliverable: report + Excel workbook with download URLs (account-gated)

**Details:**
- npm: [`@webability/mcp`](https://www.npmjs.com/package/@webability/mcp) `@1.3.0` (bin `webability-mcp`, stdio)
- Hosted: `https://mcp.webability.io`
- Auth: none for the DOM-based tools; `webability login` / `WEBABILITY_API_KEY` for the paid server-side tools
- Source: https://github.com/snayyar00/abilyo

Follows the `curated/` `Provider` schema in `curated/GENERATION.md` (slug = filename, tagline ≤ 80, 1–3 categories, every interface carries `origin`). `verified: false` — the tools are exercised end-to-end via the stdio server, but I did not probe the hosted HTTP endpoint's handshake for this record.