### PR TITLE
curated: add Keenable (web search + fetch)

### DIFF
--- a/curated/keenable.json
+++ b/curated/keenable.json
@@ -1,0 +1,85 @@
+{
+  "slug": "keenable",
+  "name": "Keenable",
+  "tagline": "Web search and page-to-markdown fetch for agents, keyless out of the box.",
+  "description": "Keenable gives agents web search and clean page-to-markdown fetch through one API. The hosted MCP server and the CLI both work with no account; an API key only lifts rate limits.",
+  "domain": "keenable.ai",
+  "icon": "https://www.google.com/s2/favicons?domain=keenable.ai&sz=64",
+  "categories": [
+    "web-search",
+    "research",
+    "developer-tools"
+  ],
+  "auth": {
+    "methods": [
+      {
+        "type": "none",
+        "label": "Keyless (free tier)",
+        "note": "MCP and CLI work with no account. Free tier is capped at 1,000 requests/hour and 10 requests/second."
+      },
+      {
+        "type": "api_key",
+        "label": "API key",
+        "note": "Sent as the X-API-Key header (Authorization: Bearer also works; X-API-Key wins if both are set). Removes the hourly cap; a per-organization rate limit applies."
+      }
+    ],
+    "guide": "**Hosted MCP (fastest, keyless):** point any MCP client at the remote server. No account is needed — the free tier allows 1,000 requests/hour.\n\n```bash\nclaude mcp add --transport http keenable https://api.keenable.ai/mcp\n```\n\n**API key (higher limits):** log in at [keenable.ai/login](https://keenable.ai/login) and create a key in the [console](https://keenable.ai/console). Send it as the `X-API-Key` header — an `Authorization: Bearer` token also works, and `X-API-Key` wins if both are present. This removes the hourly cap.\n\n```bash\ncurl \"https://api.keenable.ai/v1/search?query=anthropic+claude\" \\\n  -H \"X-API-Key: $KEENABLE_API_KEY\"\n```\n\n**CLI:** install the single binary, then optionally authenticate via a device-code flow (`keenable login` prints a link a human can open).\n\n```bash\nbrew install keenableai/tap/keenable-cli\nkeenable login   # optional — raises rate limits\nkeenable search \"rust async patterns\"\n```\n\n**Gotcha:** the keyless REST paths (`/v1/search/public`, `/v1/fetch/public`) reject token-less requests that omit an `X-Keenable-Title` header naming your app. Keyed calls to `/v1/search` and `/v1/fetch` don't need it.",
+    "sources": [
+      {
+        "title": "Keenable Docs — Quickstart",
+        "url": "https://docs.keenable.ai"
+      },
+      {
+        "title": "Keenable Docs — MCP server",
+        "url": "https://docs.keenable.ai/mcp-server"
+      },
+      {
+        "title": "Keenable Docs — Authentication",
+        "url": "https://docs.keenable.ai/authentication"
+      },
+      {
+        "title": "Keenable Docs — CLI",
+        "url": "https://docs.keenable.ai/cli"
+      }
+    ],
+    "generatedAt": "2026-07-21",
+    "verified": true
+  },
+  "interfaces": [
+    {
+      "format": "mcp",
+      "name": "Keenable MCP",
+      "origin": "vendor",
+      "endpoint": "https://api.keenable.ai/mcp",
+      "auth": "mixed",
+      "authHeader": "X-API-Key: {key}",
+      "install": "claude mcp add --transport http keenable https://api.keenable.ai/mcp",
+      "docs": "https://docs.keenable.ai/mcp-server",
+      "note": "Remote HTTP server (keenable-mcp-server). Exposes two tools: search_web_pages and fetch_page_content. Works with no API key (1,000 req/hr); add an X-API-Key header to raise limits. OAuth is supported but the vendor does not currently recommend it."
+    },
+    {
+      "format": "openapi",
+      "name": "Keenable REST API",
+      "origin": "vendor",
+      "endpoint": "https://api.keenable.ai",
+      "auth": "mixed",
+      "authHeader": "X-API-Key: {key}",
+      "docs": "https://docs.keenable.ai",
+      "note": "Keyless via /v1/search/public and /v1/fetch/public — token-less requests must send an X-Keenable-Title header naming the caller. Keyed via /v1/search and /v1/fetch with X-API-Key."
+    },
+    {
+      "format": "cli",
+      "name": "Keenable CLI",
+      "origin": "vendor",
+      "repo": "https://github.com/keenableai/keenable-cli",
+      "auth": "mixed",
+      "install": "brew install keenableai/tap/keenable-cli",
+      "docs": "https://docs.keenable.ai/cli",
+      "note": "Single binary. Works keyless; `keenable login` (device-code flow) raises rate limits. `keenable configure-mcp` wires the MCP server into Claude Code, Cursor, Windsurf, Codex, and OpenCode."
+    }
+  ],
+  "links": {
+    "homepage": "https://keenable.ai",
+    "docs": "https://docs.keenable.ai"
+  }
+}


### PR DESCRIPTION
Adds a curated provider record for **Keenable** — web search and page-to-markdown fetch for agents, keyless out of the box.

Three surfaces, all vendor-published:

- **MCP** — remote HTTP server at `https://api.keenable.ai/mcp` (tools: `search_web_pages`, `fetch_page_content`). Authless on the free tier; `X-API-Key` header raises limits.
- **REST** — `https://api.keenable.ai`; keyless `/v1/search/public` + `/v1/fetch/public`, keyed `/v1/search` + `/v1/fetch`.
- **CLI** — `brew install keenableai/tap/keenable-cli`.

Everything in the record was grounded this session against the live service, per `curated/GENERATION.md`:

- MCP `initialize` probe → `200`, `serverInfo: keenable-mcp-server 0.2.1` (authless; OAuth advertised but the vendor doesn't recommend it).
- REST `/v1/search/public` and `/v1/fetch/public` probed live. Noted the two real gotchas: token-less requests must send an `X-Keenable-Title` header, and the key goes in `X-API-Key` (Bearer also accepted, `X-API-Key` wins).
- `auth.sources` cites only the four docs pages actually fetched (Quickstart, MCP, Authentication, CLI); `verified: true`.

I'm from Keenable — happy to adjust anything to fit conventions.