### PR TITLE
add atlassian teamwork graph (twg) CLI catalog entries

### DIFF
--- a/domains/atlassian.com/integrations.json
+++ b/domains/atlassian.com/integrations.json
@@ -2,7 +2,7 @@
   "description": "Atlassian provides cloud collaboration and work-management products such as Jira, Confluence, Bitbucket, and Atlassian Administration. The atlassian.net tenant domain is used for customer-hosted Jira, Confluence, and GraphQL endpoints, while some cross-product and admin services are hosted on api.atlassian.com and mcp.atlassian.com.",
   "discoveredAt": "2026-07-02T22:53:35.215Z",
   "domain": "atlassian.net",
-  "summary": "Atlassian Cloud exposes a multi-product integration surface including tenant-hosted Jira and Confluence REST APIs, a cross-product Atlassian GraphQL API, Atlassian Cloud Admin REST APIs, the Atlassian Rovo MCP server, and the Atlassian CLI; auth uses Atlassian API tokens, OAuth 2.0 apps, admin API keys, and service-account API keys depending on surface.",
+  "summary": "Atlassian Cloud exposes a multi-product integration surface including tenant-hosted Jira and Confluence REST APIs, a cross-product Atlassian GraphQL API, Atlassian Cloud Admin REST APIs, the Atlassian Rovo MCP server, the Teamwork Graph CLI, and the Atlassian CLI; auth uses Atlassian API tokens, OAuth 2.0 apps, admin API keys, and service-account API keys depending on surface.",
   "surfaces": [
     {
       "authStatus": "required",
@@ -37,6 +37,19 @@
         }
       ],
       "slug": "atlassian-cli",
+      "type": "cli"
+    },
+    {
+      "authStatus": "required",
+      "command": "twg",
+      "name": "Atlassian Teamwork Graph CLI",
+      "packages": [
+        {
+          "identifier": "curl -fsSL https://teamwork-graph.atlassian.com/cli/install | bash",
+          "registryType": "shell"
+        }
+      ],
+      "slug": "atlassian-teamwork-graph-cli",
       "type": "cli"
     },
     {

--- a/domains/jira.com/integrations.json
+++ b/domains/jira.com/integrations.json
@@ -2,7 +2,7 @@
   "description": "Jira is Atlassian’s issue tracking and work management product. It is offered as part of Atlassian Cloud and connects with other Atlassian products such as Confluence, Jira Service Management, Bitbucket, and Rovo.",
   "discoveredAt": "2026-07-02T20:31:33.834Z",
   "domain": "jira.com",
-  "summary": "jira.com maps to Atlassian’s Jira developer surface: a Jira Cloud REST API, Atlassian GraphQL endpoints that can expose Jira data, the Atlassian Rovo MCP server, and the Atlassian CLI; authentication is via Atlassian API tokens, OAuth 2.0/2.1, and for MCP optionally service-account API keys.",
+  "summary": "jira.com maps to Atlassian’s Jira developer surface: a Jira Cloud REST API, Atlassian GraphQL endpoints that can expose Jira data, the Atlassian Rovo MCP server, the Teamwork Graph CLI, and the Atlassian CLI; authentication is via Atlassian API tokens, OAuth 2.0/2.1, and for MCP optionally service-account API keys.",
   "surfaces": [
     {
       "authStatus": "required",
@@ -35,6 +35,19 @@
         }
       ],
       "slug": "atlassian-cli",
+      "type": "cli"
+    },
+    {
+      "authStatus": "required",
+      "command": "twg",
+      "name": "Atlassian Teamwork Graph CLI",
+      "packages": [
+        {
+          "identifier": "curl -fsSL https://teamwork-graph.atlassian.com/cli/install | bash",
+          "registryType": "shell"
+        }
+      ],
+      "slug": "atlassian-teamwork-graph-cli",
       "type": "cli"
     },
     {


### PR DESCRIPTION
adds the Atlassian Teamwork Graph CLI (twg) alongside the existing Atlassian CLI entries for Atlassian Cloud and Jira.

includes the supported shell installer:
```
curl -fsSL https://teamwork-graph.atlassian.com/cli/install | bash
```

also updates the catalog summaries to list the Teamwork Graph CLI before acli (since twg will replace acli soon)