### PR TITLE
fix: MDN mcp remote url

### DIFF
--- a/domains/mozilla.org/integrations.json
+++ b/domains/mozilla.org/integrations.json
@@ -9,7 +9,7 @@
       "name": "MDN MCP server",
       "slug": "mdn-mcp-server",
       "type": "mcp",
-      "url": "https://developer.mozilla.org/api/v1/mcp"
+      "url": "https://mcp.mdn.mozilla.net/"
     }
   ]
 }


### PR DESCRIPTION
The registry is using the wrong url for MDN MCP server, maybe it's from the beta release of the MCP, but since public release it has been "https://mcp.mdn.mozilla.net/", you can checkout the [official MDN docs](https://developer.mozilla.org/en-US/mcp).