### PR TITLE
Add Palisade DMARC Agent

### DIFF
--- a/domains/api.palisade.email/integrations.json
+++ b/domains/api.palisade.email/integrations.json
@@ -1,0 +1,19 @@
+{
+  "description": "Palisade is an email-authentication management platform for monitoring and remediating SPF, DKIM, DMARC, MTA-STS, and BIMI across managed domains.",
+  "discoveredAt": "2026-08-16T00:00:00.000Z",
+  "domain": "api.palisade.email",
+  "summary": "api.palisade.email exposes a bearer-authenticated remote MCP server at `https://api.palisade.email/mcp` for managing email-authentication posture, DNS records, domains, remediation tasks, and related account settings.",
+  "surfaces": [
+    {
+      "authStatus": "required",
+      "docs": "https://developer.palisade.email/docs/guide",
+      "name": "Palisade DMARC Agent",
+      "slug": "palisade-dmarc-agent",
+      "transports": [
+        "streamable-http"
+      ],
+      "type": "mcp",
+      "url": "https://api.palisade.email/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds Palisade’s documented remote MCP surface to the catalog.

- Streamable HTTP endpoint: `https://api.palisade.email/mcp`
- Bearer authentication required
- Links to the public Palisade developer guide

## Validation

- `bun run build` passed.
- `bun run validate:batch` currently reports pre-existing catalog-wide missing-locator and duplicate-surface findings; this new entry is not among them.

No credentials are included.
