### PR TITLE
Generate api.json from live discoveries

### DIFF
--- a/src/components/Surfaces.tsx
+++ b/src/components/Surfaces.tsx
@@ -122,15 +122,18 @@ function EntryRow({ e }: { e: SurfaceEntry }) {
 function DiscoveryMeta({ discoveredAt, hasSurfaces, onRegenerate }: { discoveredAt?: string; hasSurfaces: boolean; onRegenerate: () => void }) {
   const freshness = discoveryFreshness(discoveredAt, hasSurfaces);
   // Unknown-age data (timestampless baselines) shows no age claim at all —
-  // just the regenerate affordance.
+  // just the refresh affordance. Refresh is always available: even a fresh or
+  // zero-surface result may need remapping after the provider changes its APIs.
   return (
     <div className="disc-freshness" title={freshness.title}>
       {freshness.known && <span>discovered {freshness.label}</span>}
-      {freshness.shouldRegenerate && (
-        <button className="conv-action disc-regenerate" onClick={onRegenerate}>
-          regenerate
-        </button>
-      )}
+      <button
+        className="conv-action disc-regenerate"
+        onClick={onRegenerate}
+        aria-label={freshness.shouldRegenerate ? "Refresh stale integration surfaces" : "Refresh integration surfaces"}
+      >
+        refresh surfaces
+      </button>
     </div>
   );
 }
@@ -180,11 +183,11 @@ export default function Surfaces({
   }, [domain, initialData]);
 
   async function run(opts?: { regenerate?: boolean }) {
-    const posthog = (window as { posthog?: { capture: (e: string, p?: Record<string, unknown>) => void } }).posthog;
+    const posthog = (window as { posthog?: { capture?: (e: string, p?: Record<string, unknown>) => void } }).posthog;
     if (opts?.regenerate) {
-      posthog?.capture("regenerate_clicked", { domain });
+      posthog?.capture?.("regenerate_clicked", { domain });
     } else {
-      posthog?.capture("map_surface_clicked", { domain });
+      posthog?.capture?.("map_surface_clicked", { domain });
     }
     setState("loading");
     setProgress("Starting…");
@@ -245,22 +248,22 @@ export default function Surfaces({
             setData(parsed as unknown as DiscoverData);
             setState("done");
             finished = true;
-            posthog?.capture("discovery_stream_done", { domain, surfaces: surfaceCount, duration_ms: Date.now() - started });
+            posthog?.capture?.("discovery_stream_done", { domain, surfaces: surfaceCount, duration_ms: Date.now() - started });
           } else if (ev === "error") {
             setState("error");
             finished = true;
-            posthog?.capture("discovery_stream_error", { domain });
+            posthog?.capture?.("discovery_stream_error", { domain });
           }
         }
       }
       reader.cancel().catch(() => {});
       if (!finished) {
         setState("error");
-        posthog?.capture("discovery_stream_error", { domain });
+        posthog?.capture?.("discovery_stream_error", { domain });
       }
     } catch {
       setState("error");
-      posthog?.capture("discovery_stream_error", { domain });
+      posthog?.capture?.("discovery_stream_error", { domain });
     }
   }
 
@@ -310,7 +313,7 @@ export default function Surfaces({
         </div>
       )}
       {state === "done" && data?.summary && <p className="disc-summary">{data.summary}</p>}
-      {state === "done" && hasSurfaceData && <DiscoveryMeta discoveredAt={data?.discoveredAt} hasSurfaces={hasSurfaceData} onRegenerate={regenerate} />}
+      {state === "done" && <DiscoveryMeta discoveredAt={data?.discoveredAt} hasSurfaces={hasSurfaceData} onRegenerate={regenerate} />}
 
       {built.map((sec) => (
         <section className="disc-sec" id={sec.kind} key={sec.kind}>

--- a/worker/entry.ts
+++ b/worker/entry.ts
@@ -17,7 +17,7 @@ import yogaWasmModule from "satori/yoga.wasm?module";
 import { apiContext, apiHandler } from "./api.ts";
 import { canonicalRedirect } from "./canonical.ts";
 import { discoveryDoc, discoveryKvGet } from "./discovery-doc.ts";
-import { domainsJsonWithLiveIndex, upsertLiveIndex } from "./live-index.ts";
+import { apiJsonWithLiveIndex, domainsJsonWithLiveIndex, upsertLiveIndex } from "./live-index.ts";
 import { setChat, setWebBackend, discoverWithProgress, preserveSlugs } from "./operations.ts";
 import { contextWeb, naiveWeb } from "../src/lib/contextdev.ts";
 import { DOMAIN_ALIASES, canonicalDomain } from "../src/lib/domain-aliases.ts";
@@ -32,6 +32,7 @@ import { McpDurableObject } from "./mcp-do.ts";
 // Bump when detect/discover output shape or logic changes, so the edge Cache API
 // (which survives deploys) stops serving results produced by the old code.
 const CACHE_VERSION = "20"; // 20: llms.txt content seeds discovery
+const API_JSON_CACHE_VERSION = "1";
 
 // The discovery-loop model. gpt-5.4 drives the agentic tool-calling loop
 // (search/sitemap/scrape/report). (Note: gpt-5.x rejects `reasoning_effort`
@@ -720,6 +721,19 @@ async function handleRequest(
 
     if (request.method === "GET" && url.pathname === "/api/domains.json") {
       return domainsJsonWithLiveIndex(env, url.origin);
+    }
+
+    if ((request.method === "GET" || request.method === "HEAD") && url.pathname === "/api.json") {
+      const cache = (caches as unknown as EdgeCaches).default;
+      const keyUrl = new URL(`${url.origin}/api.json`);
+      keyUrl.searchParams.set("__cv", API_JSON_CACHE_VERSION);
+      const cacheKey = new Request(keyUrl.toString(), { method: "GET" });
+      const cached = await cache.match(cacheKey);
+      if (cached) return request.method === "HEAD" ? new Response(null, cached) : cached;
+
+      const response = await apiJsonWithLiveIndex(env, url.origin);
+      if (response.ok) ctx.waitUntil(cache.put(cacheKey, response.clone()));
+      return request.method === "HEAD" ? new Response(null, response) : response;
     }
 
     // /ssr/{domain}/ is the INTERNAL render target below — never a public URL.

--- a/worker/live-index.test.ts
+++ b/worker/live-index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { appendLiveSearchResults, liveIndexEntryFromResult, mergeLiveDomains, normalizeLiveIndex, type LiveIndexEntry, type SearchResultRow } from "./live-index.ts";
+import { apiJsonWithLiveIndex, appendLiveSearchResults, liveIndexEntryFromResult, mergeLiveApiIndex, mergeLiveDomains, normalizeLiveIndex, type LiveIndexEntry, type SearchResultRow } from "./live-index.ts";
+import type { IndexRecord } from "../src/lib/data.ts";
 import type { SearchIndexEntry } from "../src/lib/search-index.ts";
 
 const staticIndex: SearchIndexEntry[] = [
@@ -146,5 +147,77 @@ describe("live index", () => {
       devtool: false,
       description: "No public developer integration surfaces were found.",
     });
+  });
+
+  test("projects new live domains into one api.json row per surface kind", () => {
+    const staticRows: IndexRecord[] = [
+      {
+        id: "openapi/static",
+        kind: "openapi",
+        slug: "static",
+        name: "Static",
+        description: "Static API",
+        domain: "static.com",
+        categories: [],
+        feeds: ["curated"],
+      },
+    ];
+
+    expect(mergeLiveApiIndex(staticRows, live)).toEqual([
+      staticRows[0],
+      {
+        id: "discovered/fresh-com-mcp",
+        kind: "mcp",
+        slug: "fresh-com",
+        name: "fresh.com",
+        description: "Fresh MCP and REST",
+        icon: "https://integrations.sh/logo/fresh.com",
+        domain: "fresh.com",
+        categories: [],
+        feeds: ["discovered"],
+      },
+      {
+        id: "discovered/fresh-com-openapi",
+        kind: "openapi",
+        slug: "fresh-com-openapi",
+        name: "fresh.com",
+        description: "Fresh MCP and REST",
+        icon: "https://integrations.sh/logo/fresh.com",
+        domain: "fresh.com",
+        categories: [],
+        feeds: ["discovered"],
+      },
+    ]);
+  });
+
+  test("generates a fresh api.json envelope from the static asset and live index", async () => {
+    const staticRows: IndexRecord[] = [
+      {
+        id: "openapi/static",
+        kind: "openapi",
+        slug: "static",
+        name: "Static",
+        description: "Static API",
+        domain: "static.com",
+        categories: [],
+        feeds: ["curated"],
+      },
+    ];
+    const env = {
+      ASSETS: {
+        fetch: async () => new Response(JSON.stringify({ version: 1, generatedAt: "2020-01-01T00:00:00.000Z", data: staticRows })),
+      },
+      DISCOVERY: {
+        get: async () => JSON.stringify(live),
+        put: async () => {},
+      },
+    };
+
+    const response = await apiJsonWithLiveIndex(env, "https://integrations.sh");
+    const body = (await response.json()) as { generatedAt: string; data: IndexRecord[] };
+
+    expect(response.headers.get("cache-control")).toBe("public, max-age=60");
+    expect(body.generatedAt).not.toBe("2020-01-01T00:00:00.000Z");
+    expect(body.data).toHaveLength(3);
   });
 });

--- a/worker/live-index.ts
+++ b/worker/live-index.ts
@@ -1,6 +1,8 @@
 import { apiEnvelope, unwrapEnvelope, type ApiEnvelope } from "../src/lib/api-envelope.ts";
 import type { DomainSummary } from "../src/lib/catalog.ts";
+import type { IndexRecord } from "../src/lib/data.ts";
 import { canonicalDomain } from "../src/lib/domain-aliases.ts";
+import { slugifyName } from "../src/lib/discover.ts";
 import { faviconUrl } from "../src/lib/favicon.ts";
 import { isSdkNotCli } from "../src/lib/surface-classify.ts";
 import type { SearchIndexEntry } from "../src/lib/search-index.ts";
@@ -36,6 +38,14 @@ export type SearchResultRow = {
   description: string;
   kinds: Kind[];
   url: string;
+};
+
+type DiscoveryEnv = Pick<Env, "DISCOVERY">;
+type CatalogEnv = Pick<Env, "ASSETS" | "DISCOVERY">;
+type ApiIndexRecord = Omit<IndexRecord, "url" | "icon" | "popularity"> & {
+  url?: string | null;
+  icon?: string | null;
+  popularity?: number | null;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -88,7 +98,7 @@ export function normalizeLiveIndex(value: unknown): LiveIndexEntry[] {
   return [...byDomain.values()].sort((a, b) => discoveredTime(b) - discoveredTime(a) || a.domain.localeCompare(b.domain));
 }
 
-export async function readLiveIndex(env: Env): Promise<LiveIndexEntry[]> {
+export async function readLiveIndex(env: DiscoveryEnv): Promise<LiveIndexEntry[]> {
   const raw = await env.DISCOVERY.get(LIVE_INDEX_KEY);
   if (!raw) return [];
   try {
@@ -113,7 +123,7 @@ export function liveIndexEntryFromResult(result: LiveDiscoveryResult, discovered
   return { domain: canonicalDomain(domain), ...(summary ? { summary } : {}), kinds: orderedKinds, discoveredAt };
 }
 
-export async function upsertLiveIndex(env: Env, result: LiveDiscoveryResult, discoveredAt: string): Promise<void> {
+export async function upsertLiveIndex(env: DiscoveryEnv, result: LiveDiscoveryResult, discoveredAt: string): Promise<void> {
   const entry = liveIndexEntryFromResult(result, discoveredAt);
   if (!entry) return;
   const existing = await readLiveIndex(env);
@@ -185,7 +195,83 @@ export function mergeLiveDomains(staticRows: readonly DomainSummary[], liveEntri
   return [...staticRows, ...liveRows];
 }
 
-export async function domainsJsonWithLiveIndex(env: Env, origin: string): Promise<Response> {
+/** Add live discoveries to the static surface index using the same one-row-per-kind
+ * projection as the catalog normalizer. Domains already present in the static
+ * build stay authoritative until the next catalog sync. */
+export function mergeLiveApiIndex(staticRows: readonly ApiIndexRecord[], liveEntries: readonly LiveIndexEntry[]): ApiIndexRecord[] {
+  const liveRows = liveEntriesNotInStatic(liveEntries, staticRows)
+    .toSorted((a, b) => a.domain.localeCompare(b.domain))
+    .flatMap((entry) => {
+      const domainSlug = slugifyName(entry.domain);
+      const description = (entry.summary ?? "").replace(/\s+/g, " ").trim().slice(0, 240);
+      return entry.kinds.map((kind, index) => ({
+        id: `discovered/${domainSlug}-${kind}`,
+        kind,
+        slug: index === 0 ? domainSlug : `${domainSlug}-${kind}`,
+        name: entry.domain,
+        description,
+        icon: faviconUrl(entry.domain) ?? undefined,
+        domain: entry.domain,
+        categories: [],
+        feeds: ["discovered"],
+      } satisfies ApiIndexRecord));
+    });
+  return [...staticRows, ...liveRows];
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isIndexRecord(value: unknown): value is ApiIndexRecord {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.id === "string" &&
+    kindOfSurfaceType(value.kind) === value.kind &&
+    typeof value.slug === "string" &&
+    typeof value.name === "string" &&
+    typeof value.description === "string" &&
+    typeof value.domain === "string" &&
+    isStringArray(value.categories) &&
+    isStringArray(value.feeds) &&
+    (value.url == null || typeof value.url === "string") &&
+    (value.icon == null || typeof value.icon === "string") &&
+    (value.popularity == null || typeof value.popularity === "number") &&
+    (value.devtool === undefined || typeof value.devtool === "boolean")
+  );
+}
+
+function parseApiIndex(value: unknown): ApiIndexRecord[] | null {
+  const data = Array.isArray(value) ? value : isRecord(value) && Array.isArray(value.data) ? value.data : null;
+  return data?.every(isIndexRecord) ? data : null;
+}
+
+/** Generate `/api.json` from the build-time index plus the durable live index.
+ * The caller owns edge caching; malformed or unavailable build assets pass
+ * through unchanged rather than publishing a partial catalog. */
+export async function apiJsonWithLiveIndex(env: CatalogEnv, origin: string): Promise<Response> {
+  const staticResponse = await env.ASSETS.fetch(`${origin}/api.json`);
+  if (!staticResponse.ok) return staticResponse;
+
+  let staticRows: ApiIndexRecord[] | null = null;
+  try {
+    staticRows = parseApiIndex(await staticResponse.clone().json());
+  } catch {
+    // The build asset is authoritative. Preserve it if it cannot be projected.
+  }
+  if (!staticRows) return staticResponse;
+
+  const merged = mergeLiveApiIndex(staticRows, await readLiveIndex(env));
+  return new Response(JSON.stringify(apiEnvelope(merged)), {
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "access-control-allow-origin": "*",
+      "cache-control": "public, max-age=60",
+    },
+  });
+}
+
+export async function domainsJsonWithLiveIndex(env: CatalogEnv, origin: string): Promise<Response> {
   const staticResponse = await env.ASSETS.fetch(`${origin}/api/domains.json`);
   if (!staticResponse.ok) return staticResponse;
 


### PR DESCRIPTION
## What changed

- Generate `/api.json` from the prerendered catalog plus the durable live-discovery index.
- Cache the generated response at the Cloudflare edge for 60 seconds.
- Preserve GET and HEAD behavior, validate the static asset boundary, and fall back to it if malformed.
- Keep this cache namespace separate from detect/discover caches.
- Expose “refresh surfaces” on every completed domain page, including fresh and zero-surface results.
- Keep discovery controls working when analytics has initialized without a `capture` method.

## Why

`/api.json` was a build-time-only artifact, so newly discovered domains were absent until the next deploy. This keeps the bulk catalog current without reading every per-domain KV record on each request.

## Checks

- `bun run build`
- `bun test` (68 passing)
- local Worker: first request generated the response; second request and HEAD returned `CF-Cache-Status: HIT` with `Cache-Control: public, max-age=60`.
- browser verification: refresh is visible on mapped and zero-surface pages, and requests `/api/:domain/discover/stream?force=1`.
