### PR TITLE
Backfill machine locators from the baseline; add Datadog OpenAPI sources

### DIFF
--- a/sources/openapi-manual.json
+++ b/sources/openapi-manual.json
@@ -10,9 +10,44 @@
       "description": "The full Cloudflare API — manage DNS, Workers, R2, KV, Zero Trust, CDN/cache, WAF, and the rest of the Cloudflare platform.",
       "openapiVer": "3.0.0",
       "origin": "https://raw.githubusercontent.com/cloudflare/api-schemas/main/openapi.json",
-      "categories": ["cloud", "developer_tools"],
+      "categories": [
+        "cloud",
+        "developer_tools"
+      ],
       "updated": "2026-06-29T00:00:00.000Z",
       "added": "2026-06-29T00:00:00.000Z"
+    },
+    {
+      "provider": "datadoghq.com",
+      "providerName": "Datadog",
+      "openapiVer": "3.0.0",
+      "categories": [
+        "monitoring",
+        "developer_tools"
+      ],
+      "updated": "2026-08-27T00:00:00.000Z",
+      "added": "2026-08-27T00:00:00.000Z",
+      "service": "v2",
+      "versionKey": "v2",
+      "title": "Datadog API v2",
+      "description": "Datadog's current API surface — metrics, logs, monitors, dashboards, incidents, security, and the rest of the observability platform.",
+      "origin": "https://raw.githubusercontent.com/DataDog/datadog-api-client-typescript/master/.generator/schemas/v2/openapi.yaml"
+    },
+    {
+      "provider": "datadoghq.com",
+      "providerName": "Datadog",
+      "openapiVer": "3.0.0",
+      "categories": [
+        "monitoring",
+        "developer_tools"
+      ],
+      "updated": "2026-08-27T00:00:00.000Z",
+      "added": "2026-08-27T00:00:00.000Z",
+      "service": "v1",
+      "versionKey": "v1",
+      "title": "Datadog API v1",
+      "description": "Datadog's v1 API — the original endpoints for metrics, events, monitors, dashboards, and downtimes still in wide use.",
+      "origin": "https://raw.githubusercontent.com/DataDog/datadog-api-client-typescript/master/.generator/schemas/v1/openapi.yaml"
     }
   ]
 }

--- a/worker/discovery-doc.test.ts
+++ b/worker/discovery-doc.test.ts
@@ -42,4 +42,82 @@ describe("discoveryDoc", () => {
   test("returns null for genuinely unknown domains", async () => {
     await expect(discoveryDoc(envWith({}), origin, "missing.com")).resolves.toBeNull();
   });
+
+  const storedDoc = (domain: string, surfaces: unknown[]) => ({
+    result: { version: 3, domain, summary: "", credentials: {}, surfaces },
+    discoveredAt: "2026-07-05T19:00:00.000Z",
+    model: "test",
+  });
+
+  test("backfills a stored surface's missing spec from a lone baseline candidate", async () => {
+    const doc = await discoveryDoc(
+      envWith({
+        kv: {
+          "notionish.com": JSON.stringify(
+            storedDoc("notionish.com", [
+              { type: "http", url: "https://api.notionish.com", slug: "rest-api" },
+              { type: "mcp", url: "https://mcp.notionish.com/mcp", slug: "mcp" },
+            ]),
+          ),
+        },
+        baseline: {
+          version: 3,
+          domain: "notionish.com",
+          surfaces: [{ type: "http", spec: "https://spec.example/openapi.json", url: "https://api.notionish.com" }],
+        },
+      }),
+      origin,
+      "notionish.com",
+    );
+
+    expect(doc?.surfaces).toHaveLength(2);
+    expect(doc?.surfaces?.[0]).toMatchObject({ slug: "rest-api", spec: "https://spec.example/openapi.json" });
+  });
+
+  test("appends baseline spec surfaces when the stored type has none and the match is ambiguous", async () => {
+    const doc = await discoveryDoc(
+      envWith({
+        kv: {
+          "datadogish.com": JSON.stringify(
+            storedDoc("datadogish.com", [{ type: "http", url: "https://api.datadogish.com/api/", slug: "http-api" }]),
+          ),
+        },
+        baseline: {
+          version: 3,
+          domain: "datadogish.com",
+          surfaces: [
+            { type: "http", spec: "https://spec.example/v2.yaml", slug: "api-v2" },
+            { type: "http", spec: "https://spec.example/v1.yaml", slug: "api-v1" },
+          ],
+        },
+      }),
+      origin,
+      "datadogish.com",
+    );
+
+    expect(doc?.surfaces).toHaveLength(3);
+    expect(doc?.surfaces?.map((s: { slug?: string }) => s.slug)).toEqual(["http-api", "api-v2", "api-v1"]);
+  });
+
+  test("leaves a type alone when a stored surface already carries its locator", async () => {
+    const stored = [{ type: "http", spec: "https://stored.example/spec.json", slug: "kept" }];
+    const doc = await discoveryDoc(
+      envWith({
+        kv: { "twilioish.com": JSON.stringify(storedDoc("twilioish.com", stored)) },
+        baseline: {
+          version: 3,
+          domain: "twilioish.com",
+          surfaces: [
+            { type: "http", spec: "https://other.example/a.json", slug: "a" },
+            { type: "http", spec: "https://other.example/b.json", slug: "b" },
+          ],
+        },
+      }),
+      origin,
+      "twilioish.com",
+    );
+
+    expect(doc?.surfaces).toHaveLength(1);
+    expect(doc?.surfaces?.[0]).toMatchObject({ slug: "kept", spec: "https://stored.example/spec.json" });
+  });
 });

--- a/worker/discovery-doc.ts
+++ b/worker/discovery-doc.ts
@@ -28,8 +28,76 @@ const stripSdkSurfaces = (doc: DiscoveryDocWithSurfaces): DiscoveryDocWithSurfac
   surfaces: doc.surfaces.filter((s) => !isSdkNotCli(s)),
 });
 
-/** The domain page's render source: durable discovery result first, then the
- * prerendered baseline discovery JSON. */
+type SurfaceLike = {
+  type?: string;
+  url?: string;
+  spec?: string;
+  slug?: string;
+};
+
+/** The machine locator per surface type — what a consumer needs to actually
+ * connect (an http surface's docs page or base URL is not it). */
+const locatorField = (type: string | undefined): "spec" | "url" | null =>
+  type === "http" || type === "graphql" ? "spec" : type === "mcp" ? "url" : null;
+
+// GraphQL's connectable locator is really the endpoint; treat a surface as
+// machine-reachable when either the endpoint or the SDL pointer is present.
+const hasLocator = (s: SurfaceLike): boolean =>
+  s.type === "graphql" ? !!(s.url ?? s.spec) : !!s[locatorField(s.type) ?? "url"];
+
+/**
+ * Live-discovered docs sometimes drop the machine locators the static catalog
+ * carries (the LLM found the API but not its spec URL). Backfill from the
+ * baseline, conservatively, per surface type:
+ * - any stored surface of the type already has a locator → leave the type alone;
+ * - exactly one stored surface and one locator-bearing baseline candidate →
+ *   fill the stored surface's missing `spec`/`url`;
+ * - otherwise append the baseline's locator-bearing surfaces (slug-deduped),
+ *   so registry-known specs stay reachable alongside the discovered surface.
+ */
+const backfillBaselineLocators = (
+  stored: DiscoveryDocWithSurfaces,
+  baseline: DiscoveryDocWithSurfaces,
+): DiscoveryDocWithSurfaces => {
+  const surfaces: SurfaceLike[] = [...stored.surfaces];
+  const takenSlugs = new Set(surfaces.map((s) => s.slug).filter(Boolean));
+  for (const type of ["http", "graphql", "mcp"]) {
+    const storedOfType = surfaces.filter((s) => s.type === type);
+    if (storedOfType.some(hasLocator)) continue;
+    const candidates = (baseline.surfaces as SurfaceLike[]).filter(
+      (s) => s.type === type && hasLocator(s),
+    );
+    if (candidates.length === 0) continue;
+    if (storedOfType.length === 1 && candidates.length === 1) {
+      const target = storedOfType[0]!;
+      const source = candidates[0]!;
+      if (!target.spec && source.spec) target.spec = source.spec;
+      if (!target.url && source.url) target.url = source.url;
+      continue;
+    }
+    for (const candidate of candidates) {
+      if (candidate.slug && takenSlugs.has(candidate.slug)) continue;
+      if (candidate.slug) takenSlugs.add(candidate.slug);
+      surfaces.push(candidate);
+    }
+  }
+  return { ...stored, surfaces: surfaces as DiscoveryDocWithSurfaces["surfaces"] };
+};
+
+const baselineDoc = async (
+  env: Env,
+  origin: string,
+  canonical: string,
+): Promise<DiscoveryDocWithSurfaces | null> => {
+  const res = await env.ASSETS.fetch(`${origin}/disc/${encodeURIComponent(canonical)}.json`);
+  if (!res.ok) return null;
+  const baseline = (await res.json()) as DiscoverData;
+  return hasSurfaceArray(baseline) ? baseline : null;
+};
+
+/** The domain page's render source: durable discovery result first (with
+ * missing machine locators backfilled from the baseline), then the prerendered
+ * baseline discovery JSON. */
 export async function discoveryDoc(env: Env, origin: string, domain: string): Promise<DiscoverData | null> {
   const canonical = canonicalDomain(domain);
   try {
@@ -37,14 +105,13 @@ export async function discoveryDoc(env: Env, origin: string, domain: string): Pr
     if (raw) {
       const stored = JSON.parse(raw) as { result?: DiscoverData; discoveredAt?: string };
       if (hasSurfaceArray(stored.result)) {
-        return stripSdkSurfaces({ ...stored.result, discoveredAt: stored.result.discoveredAt ?? stored.discoveredAt });
+        const doc = { ...stored.result, discoveredAt: stored.result.discoveredAt ?? stored.discoveredAt };
+        const baseline = await baselineDoc(env, origin, canonical);
+        return stripSdkSurfaces(baseline ? backfillBaselineLocators(doc, baseline) : doc);
       }
     }
-    const res = await env.ASSETS.fetch(`${origin}/disc/${encodeURIComponent(canonical)}.json`);
-    if (res.ok) {
-      const baseline = (await res.json()) as DiscoverData;
-      if (hasSurfaceArray(baseline)) return stripSdkSurfaces(baseline);
-    }
+    const baseline = await baselineDoc(env, origin, canonical);
+    if (baseline) return stripSdkSurfaces(baseline);
   } catch {
     /* unavailable or malformed discovery data */
   }


### PR DESCRIPTION
Live-discovered KV docs sometimes drop the machine locators the static catalog has — the LLM finds the API but not its spec URL — so /api/{domain}/surface consumers get surfaces they can't connect to.

- discoveryDoc now backfills from the prerendered baseline per surface type: fill the missing spec/url when the match is unambiguous, append the baseline's locator-bearing surfaces when a type has none at all, and leave types alone that already carry a locator (so curated multi-spec docs like Twilio's are untouched).
- Adds Datadog's official v1/v2 OpenAPI specs to sources/openapi-manual.json — the domain previously existed only as a discovered shim with no spec pointer at all.