### PR TITLE
Registry accuracy: curated records, duplicate specs, dead endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,9 @@ scripts/batch/scrape-cache/
 scripts/batch/kv-bulk.json
 
 # Derived by `bun run normalize` (runs as part of every build) — not source.
-# output/tools/ and output/favicons.json stay tracked: they're slow network
-# caches (extract-tools / validate-favicons) that normalize only reads.
+# output/tools/, output/favicons.json and output/mcp-endpoints.json stay
+# tracked: they're slow network caches (extract-tools / validate-favicons /
+# verify-mcp-endpoints) that normalize only reads.
 output/cli.json
 output/graphql.json
 output/index.json

--- a/curated/github.json
+++ b/curated/github.json
@@ -2,7 +2,7 @@
   "slug": "github",
   "name": "GitHub",
   "tagline": "Repos, issues, PRs, and Actions in every format agents speak.",
-  "description": "GitHub exposes more agent-callable surface area than almost any service: an official remote MCP server, a fully-specified REST API, a GraphQL API, and the `gh` CLI. Pick the format that fits your agent — they all reach the same data.",
+  "description": "GitHub exposes more agent-callable surface area than almost any service: an official remote MCP server, a fully-specified REST API, a GraphQL API, and the `gh` CLI. Pick the format that fits your agent \u2014 they all reach the same data.",
   "domain": "github.com",
   "icon": "https://www.google.com/s2/favicons?domain=github.com&sz=64",
   "categories": [
@@ -22,14 +22,14 @@
         "note": "Fine-grained PATs let you scope access per-repo and per-permission."
       }
     ],
-    "guide": "**Remote MCP (easiest):** point your client at `https://api.githubcopilot.com/mcp/`. Clients with OAuth support (VS Code 1.101+, Claude Code, Cursor) handle the consent flow automatically. For clients without OAuth, pass a PAT instead: `Authorization: Bearer <your-pat>`.\n\n**Personal access token:** create one under [Settings → Developer settings → Personal access tokens](https://github.com/settings/tokens). Prefer fine-grained tokens scoped to the repos and permissions your agent actually needs. Use it with REST and GraphQL:\n\n```bash\n# REST\ncurl https://api.github.com/user -H \"Authorization: Bearer $GITHUB_TOKEN\"\n\n# GraphQL\ncurl https://api.github.com/graphql \\\n  -H \"Authorization: Bearer $GITHUB_TOKEN\" \\\n  -d '{\"query\": \"{ viewer { login } }\"}'\n```\n\n**CLI:** `gh auth login` stores credentials in your keychain; agents running in your shell inherit them. This is often the lowest-friction path for coding agents.",
+    "guide": "**Remote MCP (easiest):** point your client at `https://api.githubcopilot.com/mcp/`. Clients with OAuth support (VS Code 1.101+, Claude Code, Cursor) handle the consent flow automatically. For clients without OAuth, pass a PAT instead: `Authorization: Bearer <your-pat>`.\n\n**Personal access token:** create one under [Settings \u2192 Developer settings \u2192 Personal access tokens](https://github.com/settings/tokens). Prefer fine-grained tokens scoped to the repos and permissions your agent actually needs. Use it with REST and GraphQL:\n\n```bash\n# REST\ncurl https://api.github.com/user -H \"Authorization: Bearer $GITHUB_TOKEN\"\n\n# GraphQL\ncurl https://api.github.com/graphql \\\n  -H \"Authorization: Bearer $GITHUB_TOKEN\" \\\n  -d '{\"query\": \"{ viewer { login } }\"}'\n```\n\n**CLI:** `gh auth login` stores credentials in your keychain; agents running in your shell inherit them. This is often the lowest-friction path for coding agents.",
     "sources": [
       {
-        "title": "github/github-mcp-server — remote server & PAT setup",
+        "title": "github/github-mcp-server \u2014 remote server & PAT setup",
         "url": "https://github.com/github/github-mcp-server"
       },
       {
-        "title": "GitHub REST API — authenticating",
+        "title": "GitHub REST API \u2014 authenticating",
         "url": "https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api"
       }
     ],
@@ -51,6 +51,7 @@
       "format": "openapi",
       "name": "GitHub REST API",
       "endpoint": "https://api.github.com",
+      "spec": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json",
       "specUrl": "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json",
       "auth": "token",
       "authHeader": "Authorization: Bearer {pat}",

--- a/curated/notion.json
+++ b/curated/notion.json
@@ -2,8 +2,8 @@
   "slug": "notion",
   "name": "Notion",
   "tagline": "Pages, databases, and comments as agent-editable workspace memory.",
-  "description": "Notion's hosted MCP server lets agents search, create, and reorganize workspace content. The REST API underneath uses internal integrations with explicit page-level sharing — a natural permission boundary for agents.",
-  "domain": "notion.so",
+  "description": "Notion's hosted MCP server lets agents search, create, and reorganize workspace content. The REST API underneath uses internal integrations with explicit page-level sharing \u2014 a natural permission boundary for agents.",
+  "domain": "notion.com",
   "icon": "https://www.notion.so/images/notion-logo-block-main.svg",
   "categories": [
     "productivity",
@@ -22,10 +22,10 @@
         "note": "For personal/workspace automations; pages must be explicitly shared with the integration."
       }
     ],
-    "guide": "**MCP with OAuth (easiest):** add `https://mcp.notion.com/mcp` in an OAuth-capable client and approve access.\n\n```bash\nclaude mcp add --transport http notion https://mcp.notion.com/mcp\n```\n\n**Internal integration (REST):** create one at [notion.so/profile/integrations](https://www.notion.so/profile/integrations) and copy the secret (`ntn_…`). Crucially, **integrations see nothing by default** — open each page or database the agent should access and share it via *⋯ → Connections → your integration*:\n\n```bash\ncurl https://api.notion.com/v1/search \\\n  -H \"Authorization: Bearer $NOTION_TOKEN\" \\\n  -H \"Notion-Version: 2022-06-28\" \\\n  -X POST\n```\n\nThe `Notion-Version` header is required on every request. The page-sharing model doubles as your agent's permission scope: share only what it should touch.",
+    "guide": "**MCP with OAuth (easiest):** add `https://mcp.notion.com/mcp` in an OAuth-capable client and approve access.\n\n```bash\nclaude mcp add --transport http notion https://mcp.notion.com/mcp\n```\n\n**Internal integration (REST):** create one at [notion.so/profile/integrations](https://www.notion.so/profile/integrations) and copy the secret (`ntn_\u2026`). Crucially, **integrations see nothing by default** \u2014 open each page or database the agent should access and share it via *\u22ef \u2192 Connections \u2192 your integration*:\n\n```bash\ncurl https://api.notion.com/v1/search \\\n  -H \"Authorization: Bearer $NOTION_TOKEN\" \\\n  -H \"Notion-Version: 2022-06-28\" \\\n  -X POST\n```\n\nThe `Notion-Version` header is required on every request. The page-sharing model doubles as your agent's permission scope: share only what it should touch.",
     "sources": [
       {
-        "title": "Notion Developers — Authorization",
+        "title": "Notion Developers \u2014 Authorization",
         "url": "https://developers.notion.com/docs/authorization"
       }
     ],
@@ -45,6 +45,7 @@
       "format": "openapi",
       "name": "Notion REST API",
       "endpoint": "https://api.notion.com/v1",
+      "spec": "https://raw.githubusercontent.com/makenotion/notion-mcp-server/main/scripts/notion-openapi.json",
       "auth": "api_key",
       "authHeader": "Authorization: Bearer {ntn_token}",
       "docs": "https://developers.notion.com/reference",

--- a/curated/posthog.json
+++ b/curated/posthog.json
@@ -17,14 +17,14 @@
         "note": "Scoped keys created per-use; used by both the MCP server and REST API."
       }
     ],
-    "guide": "Create a personal API key under [Settings → Personal API keys](https://app.posthog.com/settings/user-api-keys) (`phx_…`). Choose the **MCP Server** preset when creating it — that grants exactly the scopes the MCP tools need.\n\n**MCP (hosted):**\n\n```bash\nclaude mcp add --transport http posthog https://mcp.posthog.com/mcp \\\n  --header \"Authorization: Bearer phx_your_key\"\n```\n\n**REST API:** the same key works against the private API:\n\n```bash\ncurl https://us.posthog.com/api/projects/ \\\n  -H \"Authorization: Bearer $POSTHOG_API_KEY\"\n```\n\nNote the **region split**: US Cloud uses `us.posthog.com`, EU Cloud uses `eu.posthog.com` — match your instance or you'll get auth errors with a valid key. Project API keys (`phc_…`) are for event *capture* only and won't work here.",
+    "guide": "Create a personal API key under [Settings \u2192 Personal API keys](https://app.posthog.com/settings/user-api-keys) (`phx_\u2026`). Choose the **MCP Server** preset when creating it \u2014 that grants exactly the scopes the MCP tools need.\n\n**MCP (hosted):**\n\n```bash\nclaude mcp add --transport http posthog https://mcp.posthog.com/mcp \\\n  --header \"Authorization: Bearer phx_your_key\"\n```\n\n**REST API:** the same key works against the private API:\n\n```bash\ncurl https://us.posthog.com/api/projects/ \\\n  -H \"Authorization: Bearer $POSTHOG_API_KEY\"\n```\n\nNote the **region split**: US Cloud uses `us.posthog.com`, EU Cloud uses `eu.posthog.com` \u2014 match your instance or you'll get auth errors with a valid key. Project API keys (`phc_\u2026`) are for event *capture* only and won't work here.",
     "sources": [
       {
-        "title": "PostHog Docs — MCP server",
+        "title": "PostHog Docs \u2014 MCP server",
         "url": "https://posthog.com/docs/model-context-protocol"
       },
       {
-        "title": "PostHog Docs — Personal API keys",
+        "title": "PostHog Docs \u2014 Personal API keys",
         "url": "https://posthog.com/docs/api"
       }
     ],
@@ -45,6 +45,7 @@
       "format": "openapi",
       "name": "PostHog REST API",
       "endpoint": "https://us.posthog.com/api",
+      "spec": "https://us.posthog.com/api/schema/",
       "auth": "api_key",
       "authHeader": "Authorization: Bearer {phx_key}",
       "docs": "https://posthog.com/docs/api",

--- a/curated/resend.json
+++ b/curated/resend.json
@@ -18,14 +18,14 @@
         "note": "One key, sent as a bearer header. Scoped keys can restrict to sending-only."
       }
     ],
-    "guide": "Create an API key at [resend.com/api-keys](https://resend.com/api-keys) (`re_…`). Keys can be **full access** or restricted to **sending access** only — prefer the latter for agents that just send mail.\n\n```bash\ncurl https://api.resend.com/emails \\\n  -H \"Authorization: Bearer $RESEND_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"from\": \"you@yourdomain.com\", \"to\": [\"them@example.com\"], \"subject\": \"Hi\", \"text\": \"Hello from an agent.\"}'\n```\n\n**MCP (stdio):** the official server runs locally with the same key:\n\n```bash\nclaude mcp add resend -e RESEND_API_KEY=re_xxxxxxxxx -- npx -y resend-mcp\n```\n\nYou'll need a verified sending domain before production sends — set one up under [Domains](https://resend.com/domains).",
+    "guide": "Create an API key at [resend.com/api-keys](https://resend.com/api-keys) (`re_\u2026`). Keys can be **full access** or restricted to **sending access** only \u2014 prefer the latter for agents that just send mail.\n\n```bash\ncurl https://api.resend.com/emails \\\n  -H \"Authorization: Bearer $RESEND_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"from\": \"you@yourdomain.com\", \"to\": [\"them@example.com\"], \"subject\": \"Hi\", \"text\": \"Hello from an agent.\"}'\n```\n\n**MCP (stdio):** the official server runs locally with the same key:\n\n```bash\nclaude mcp add resend -e RESEND_API_KEY=re_xxxxxxxxx -- npx -y resend-mcp\n```\n\nYou'll need a verified sending domain before production sends \u2014 set one up under [Domains](https://resend.com/domains).",
     "sources": [
       {
-        "title": "Resend Docs — API keys & authentication",
+        "title": "Resend Docs \u2014 API keys & authentication",
         "url": "https://resend.com/docs/api-reference/introduction"
       },
       {
-        "title": "Resend Docs — MCP server",
+        "title": "Resend Docs \u2014 MCP server",
         "url": "https://resend.com/docs/mcp-server"
       }
     ],
@@ -46,6 +46,7 @@
       "format": "openapi",
       "name": "Resend REST API",
       "endpoint": "https://api.resend.com",
+      "spec": "https://raw.githubusercontent.com/resend/resend-openapi/main/resend.yaml",
       "auth": "api_key",
       "authHeader": "Authorization: Bearer {re_key}",
       "docs": "https://resend.com/docs/api-reference",

--- a/curated/sentry.json
+++ b/curated/sentry.json
@@ -2,7 +2,7 @@
   "slug": "sentry",
   "name": "Sentry",
   "tagline": "Errors, traces, and root-cause analysis for debugging agents.",
-  "description": "Sentry's hosted MCP server gives agents direct access to issues, events, releases, and Seer root-cause runs — the context a coding agent needs to fix what's actually broken in production.",
+  "description": "Sentry's hosted MCP server gives agents direct access to issues, events, releases, and Seer root-cause runs \u2014 the context a coding agent needs to fix what's actually broken in production.",
   "domain": "sentry.io",
   "icon": "https://www.google.com/s2/favicons?domain=sentry.dev&sz=64",
   "categories": [
@@ -22,14 +22,14 @@
         "note": "Organization or personal tokens for the REST API and CI."
       }
     ],
-    "guide": "**MCP with OAuth (easiest):** add `https://mcp.sentry.dev/mcp` in an OAuth-capable client and approve access to your org.\n\n```bash\nclaude mcp add --transport http sentry https://mcp.sentry.dev/mcp\n```\n\n**Auth tokens (REST):** create an organization token under [Settings → Auth Tokens](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/) — or a personal token under User settings — and send it as a bearer header:\n\n```bash\ncurl https://sentry.io/api/0/projects/ \\\n  -H \"Authorization: Bearer $SENTRY_AUTH_TOKEN\"\n```\n\nOrganization tokens are scoped at creation; give debugging agents read-only event/issue scopes unless they need to resolve or assign.",
+    "guide": "**MCP with OAuth (easiest):** add `https://mcp.sentry.dev/mcp` in an OAuth-capable client and approve access to your org.\n\n```bash\nclaude mcp add --transport http sentry https://mcp.sentry.dev/mcp\n```\n\n**Auth tokens (REST):** create an organization token under [Settings \u2192 Auth Tokens](https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/) \u2014 or a personal token under User settings \u2014 and send it as a bearer header:\n\n```bash\ncurl https://sentry.io/api/0/projects/ \\\n  -H \"Authorization: Bearer $SENTRY_AUTH_TOKEN\"\n```\n\nOrganization tokens are scoped at creation; give debugging agents read-only event/issue scopes unless they need to resolve or assign.",
     "sources": [
       {
-        "title": "Sentry Docs — MCP server",
+        "title": "Sentry Docs \u2014 MCP server",
         "url": "https://docs.sentry.io/product/sentry-mcp/"
       },
       {
-        "title": "Sentry Docs — Auth tokens",
+        "title": "Sentry Docs \u2014 Auth tokens",
         "url": "https://docs.sentry.io/account/auth-tokens/"
       }
     ],
@@ -49,6 +49,7 @@
       "format": "openapi",
       "name": "Sentry Web API",
       "endpoint": "https://sentry.io/api/0",
+      "spec": "https://raw.githubusercontent.com/getsentry/sentry-api-schema/main/openapi-derefed.json",
       "auth": "token",
       "authHeader": "Authorization: Bearer {auth_token}",
       "docs": "https://docs.sentry.io/api/",

--- a/curated/slack.json
+++ b/curated/slack.json
@@ -2,7 +2,7 @@
   "slug": "slack",
   "name": "Slack",
   "tagline": "Read, search, and send messages where your team already works.",
-  "description": "Slack's hosted MCP server covers messaging, search, and canvases. The underlying Web API is one of the most battle-tested REST surfaces anywhere — token-based, method-oriented, and fully documented.",
+  "description": "Slack's hosted MCP server covers messaging, search, and canvases. The underlying Web API is one of the most battle-tested REST surfaces anywhere \u2014 token-based, method-oriented, and fully documented.",
   "domain": "slack.com",
   "icon": "https://www.google.com/s2/favicons?domain=slack.com&sz=64",
   "categories": [
@@ -22,10 +22,10 @@
         "note": "Issued after app install; sent as a bearer header to the Web API."
       }
     ],
-    "guide": "**MCP with OAuth (easiest):** create a [pre-configured Slack app](https://api.slack.com/apps?new_app=1&manifest_json=%7B%22display_information%22%3A%7B%22name%22%3A%22Slack%20MCP%20client%22%7D%2C%22oauth_config%22%3A%7B%22scopes%22%3A%7B%22user%22%3A%5B%22search%3Aread.public%22%2C%22search%3Aread.private%22%2C%22search%3Aread.mpim%22%2C%22search%3Aread.im%22%2C%22search%3Aread.files%22%2C%22search%3Aread.users%22%2C%22chat%3Awrite%22%2C%22channels%3Ahistory%22%2C%22groups%3Ahistory%22%2C%22mpim%3Ahistory%22%2C%22im%3Ahistory%22%2C%22canvases%3Aread%22%2C%22canvases%3Awrite%22%2C%22users%3Aread%22%2C%22users%3Aread.email%22%2C%22reactions%3Awrite%22%2C%22reactions%3Aread%22%2C%22emoji%3Aread%22%2C%22files%3Aread%22%2C%22channels%3Awrite%22%2C%22groups%3Awrite%22%2C%22im%3Awrite%22%2C%22mpim%3Awrite%22%2C%22channels%3Aread%22%2C%22groups%3Aread%22%2C%22mpim%3Aread%22%5D%7D%7D%2C%22settings%22%3A%7B%22org_deploy_enabled%22%3Afalse%2C%22socket_mode_enabled%22%3Afalse%2C%22token_rotation_enabled%22%3Afalse%2C%22is_mcp_enabled%22%3Atrue%7D%7D), add your MCP client's callback URL under OAuth & Permissions, then copy the client ID and secret from Basic Information. The manifest enables `settings.is_mcp_enabled: true`; Slack rejects MCP tokens from apps without it. Point the client at `https://mcp.slack.com/mcp` after the app is configured.\n\n```bash\nclaude mcp add --transport http slack https://mcp.slack.com/mcp\n```\n\n**Web API tokens:** create an app at [api.slack.com/apps](https://api.slack.com/apps), add the scopes you need (e.g. `chat:write`, `channels:read`, `search:read`), and install it to your workspace. That issues a bot token (`xoxb-…`) or user token (`xoxp-…`):\n\n```bash\ncurl https://slack.com/api/conversations.list \\\n  -H \"Authorization: Bearer xoxb-your-token\"\n```\n\nScopes are enforced per-method — if an agent only needs to read and post, don't grant admin scopes. Workspace admins can restrict which apps install at all.",
+    "guide": "**MCP with OAuth (easiest):** create a [pre-configured Slack app](https://api.slack.com/apps?new_app=1&manifest_json=%7B%22display_information%22%3A%7B%22name%22%3A%22Slack%20MCP%20client%22%7D%2C%22oauth_config%22%3A%7B%22scopes%22%3A%7B%22user%22%3A%5B%22search%3Aread.public%22%2C%22search%3Aread.private%22%2C%22search%3Aread.mpim%22%2C%22search%3Aread.im%22%2C%22search%3Aread.files%22%2C%22search%3Aread.users%22%2C%22chat%3Awrite%22%2C%22channels%3Ahistory%22%2C%22groups%3Ahistory%22%2C%22mpim%3Ahistory%22%2C%22im%3Ahistory%22%2C%22canvases%3Aread%22%2C%22canvases%3Awrite%22%2C%22users%3Aread%22%2C%22users%3Aread.email%22%2C%22reactions%3Awrite%22%2C%22reactions%3Aread%22%2C%22emoji%3Aread%22%2C%22files%3Aread%22%2C%22channels%3Awrite%22%2C%22groups%3Awrite%22%2C%22im%3Awrite%22%2C%22mpim%3Awrite%22%2C%22channels%3Aread%22%2C%22groups%3Aread%22%2C%22mpim%3Aread%22%5D%7D%7D%2C%22settings%22%3A%7B%22org_deploy_enabled%22%3Afalse%2C%22socket_mode_enabled%22%3Afalse%2C%22token_rotation_enabled%22%3Afalse%2C%22is_mcp_enabled%22%3Atrue%7D%7D), add your MCP client's callback URL under OAuth & Permissions, then copy the client ID and secret from Basic Information. The manifest enables `settings.is_mcp_enabled: true`; Slack rejects MCP tokens from apps without it. Point the client at `https://mcp.slack.com/mcp` after the app is configured.\n\n```bash\nclaude mcp add --transport http slack https://mcp.slack.com/mcp\n```\n\n**Web API tokens:** create an app at [api.slack.com/apps](https://api.slack.com/apps), add the scopes you need (e.g. `chat:write`, `channels:read`, `search:read`), and install it to your workspace. That issues a bot token (`xoxb-\u2026`) or user token (`xoxp-\u2026`):\n\n```bash\ncurl https://slack.com/api/conversations.list \\\n  -H \"Authorization: Bearer xoxb-your-token\"\n```\n\nScopes are enforced per-method \u2014 if an agent only needs to read and post, don't grant admin scopes. Workspace admins can restrict which apps install at all.",
     "sources": [
       {
-        "title": "Slack API — Web API basics & tokens",
+        "title": "Slack API \u2014 Web API basics & tokens",
         "url": "https://docs.slack.dev/apis/web-api/"
       }
     ],
@@ -45,6 +45,7 @@
       "format": "openapi",
       "name": "Slack Web API",
       "endpoint": "https://slack.com/api",
+      "spec": "https://raw.githubusercontent.com/slackapi/slack-api-specs/master/web-api/slack_web_openapi_v2.json",
       "auth": "token",
       "authHeader": "Authorization: Bearer {xoxb_token}",
       "docs": "https://docs.slack.dev/apis/web-api/",

--- a/curated/spotify.json
+++ b/curated/spotify.json
@@ -17,10 +17,10 @@
         "note": "Authorization-code flow for user data; client-credentials for catalog-only access."
       }
     ],
-    "guide": "Register an app in the [Developer Dashboard](https://developer.spotify.com/dashboard) to get a client ID and secret.\n\n**Catalog-only access** (search, metadata — no user data) uses the client-credentials flow:\n\n```bash\ncurl -X POST https://accounts.spotify.com/api/token \\\n  -d grant_type=client_credentials \\\n  -d client_id=$SPOTIFY_CLIENT_ID \\\n  -d client_secret=$SPOTIFY_CLIENT_SECRET\n```\n\n**User data** (playlists, library, playback) needs the authorization-code flow: send the user to `https://accounts.spotify.com/authorize` with your scopes (e.g. `playlist-modify-private`, `user-read-playback-state`), then exchange the code for tokens. Access tokens expire after one hour — store and rotate the refresh token.\n\n```bash\ncurl https://api.spotify.com/v1/me/playlists \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\"\n```",
+    "guide": "Register an app in the [Developer Dashboard](https://developer.spotify.com/dashboard) to get a client ID and secret.\n\n**Catalog-only access** (search, metadata \u2014 no user data) uses the client-credentials flow:\n\n```bash\ncurl -X POST https://accounts.spotify.com/api/token \\\n  -d grant_type=client_credentials \\\n  -d client_id=$SPOTIFY_CLIENT_ID \\\n  -d client_secret=$SPOTIFY_CLIENT_SECRET\n```\n\n**User data** (playlists, library, playback) needs the authorization-code flow: send the user to `https://accounts.spotify.com/authorize` with your scopes (e.g. `playlist-modify-private`, `user-read-playback-state`), then exchange the code for tokens. Access tokens expire after one hour \u2014 store and rotate the refresh token.\n\n```bash\ncurl https://api.spotify.com/v1/me/playlists \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\"\n```",
     "sources": [
       {
-        "title": "Spotify for Developers — Authorization",
+        "title": "Spotify for Developers \u2014 Authorization",
         "url": "https://developer.spotify.com/documentation/web-api/concepts/authorization"
       }
     ],
@@ -32,6 +32,7 @@
       "format": "openapi",
       "name": "Spotify Web API",
       "endpoint": "https://api.spotify.com/v1",
+      "spec": "https://raw.githubusercontent.com/sonallux/spotify-web-api/refs/heads/main/official-spotify-open-api.yml",
       "auth": "oauth",
       "authHeader": "Authorization: Bearer {access_token}",
       "docs": "https://developer.spotify.com/documentation/web-api",

--- a/curated/stripe.json
+++ b/curated/stripe.json
@@ -22,14 +22,14 @@
         "note": "For autonomous agents and non-OAuth clients. Never hand an agent your full secret key."
       }
     ],
-    "guide": "**MCP with OAuth (recommended):** add `https://mcp.stripe.com` in any OAuth-capable client and approve the consent form. Sessions are visible and revocable under [Dashboard → user settings → OAuth sessions](https://dashboard.stripe.com/settings/user). An admin must first [enable MCP access](https://dashboard.stripe.com/settings/mcp) — it's managed separately for sandbox and live mode.\n\n```bash\nclaude mcp add --transport http stripe https://mcp.stripe.com/\n```\n\n**Restricted API key (autonomous agents):** create a *restricted* key under [Developers → API keys](https://dashboard.stripe.com/apikeys) with only the permissions your agent needs, then pass it as a bearer header:\n\n```json\n\"stripe\": {\n  \"url\": \"https://mcp.stripe.com\",\n  \"headers\": { \"Authorization\": \"Bearer rk_live_...\" }\n}\n```\n\nThe same key works against the REST API directly (`curl https://api.stripe.com/v1/customers -u \"rk_live_...:\"`). Supply keys via environment variables or a secrets vault — never inline in config that gets committed.",
+    "guide": "**MCP with OAuth (recommended):** add `https://mcp.stripe.com` in any OAuth-capable client and approve the consent form. Sessions are visible and revocable under [Dashboard \u2192 user settings \u2192 OAuth sessions](https://dashboard.stripe.com/settings/user). An admin must first [enable MCP access](https://dashboard.stripe.com/settings/mcp) \u2014 it's managed separately for sandbox and live mode.\n\n```bash\nclaude mcp add --transport http stripe https://mcp.stripe.com/\n```\n\n**Restricted API key (autonomous agents):** create a *restricted* key under [Developers \u2192 API keys](https://dashboard.stripe.com/apikeys) with only the permissions your agent needs, then pass it as a bearer header:\n\n```json\n\"stripe\": {\n  \"url\": \"https://mcp.stripe.com\",\n  \"headers\": { \"Authorization\": \"Bearer rk_live_...\" }\n}\n```\n\nThe same key works against the REST API directly (`curl https://api.stripe.com/v1/customers -u \"rk_live_...:\"`). Supply keys via environment variables or a secrets vault \u2014 never inline in config that gets committed.",
     "sources": [
       {
-        "title": "Stripe Docs — Model Context Protocol",
+        "title": "Stripe Docs \u2014 Model Context Protocol",
         "url": "https://docs.stripe.com/mcp"
       },
       {
-        "title": "Stripe Docs — API keys",
+        "title": "Stripe Docs \u2014 API keys",
         "url": "https://docs.stripe.com/keys"
       }
     ],
@@ -51,6 +51,7 @@
       "format": "openapi",
       "name": "Stripe REST API",
       "endpoint": "https://api.stripe.com",
+      "spec": "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json",
       "specUrl": "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json",
       "auth": "api_key",
       "authHeader": "Authorization: Bearer {secret_key}",

--- a/curated/vercel.json
+++ b/curated/vercel.json
@@ -2,7 +2,7 @@
   "slug": "vercel",
   "name": "Vercel",
   "tagline": "Deployments, projects, and logs your agent can ship with.",
-  "description": "Vercel's official MCP server covers documentation search, project management, and deployment analysis. The REST API and CLI give agents full control of the deploy loop — push, inspect, roll back.",
+  "description": "Vercel's official MCP server covers documentation search, project management, and deployment analysis. The REST API and CLI give agents full control of the deploy loop \u2014 push, inspect, roll back.",
   "domain": "vercel.com",
   "icon": "https://www.google.com/s2/favicons?domain=vercel.com&sz=64",
   "categories": [
@@ -22,14 +22,14 @@
         "note": "Account tokens for the REST API; scope to a team where possible."
       }
     ],
-    "guide": "**MCP with OAuth (easiest):** add `https://mcp.vercel.com` in an OAuth-capable client and approve access.\n\n```bash\nclaude mcp add --transport http vercel https://mcp.vercel.com\n```\n\n**Access token (REST):** create one under [Account Settings → Tokens](https://vercel.com/account/settings/tokens), choose the team scope and an expiry, then send it as a bearer header:\n\n```bash\ncurl https://api.vercel.com/v9/projects \\\n  -H \"Authorization: Bearer $VERCEL_TOKEN\"\n```\n\n**CLI:** `vercel login` authenticates the `vercel` CLI; agents running in your shell can then deploy (`vercel deploy`), inspect (`vercel inspect`), and read logs (`vercel logs`) without extra setup.",
+    "guide": "**MCP with OAuth (easiest):** add `https://mcp.vercel.com` in an OAuth-capable client and approve access.\n\n```bash\nclaude mcp add --transport http vercel https://mcp.vercel.com\n```\n\n**Access token (REST):** create one under [Account Settings \u2192 Tokens](https://vercel.com/account/settings/tokens), choose the team scope and an expiry, then send it as a bearer header:\n\n```bash\ncurl https://api.vercel.com/v9/projects \\\n  -H \"Authorization: Bearer $VERCEL_TOKEN\"\n```\n\n**CLI:** `vercel login` authenticates the `vercel` CLI; agents running in your shell can then deploy (`vercel deploy`), inspect (`vercel inspect`), and read logs (`vercel logs`) without extra setup.",
     "sources": [
       {
-        "title": "Vercel Docs — MCP server",
+        "title": "Vercel Docs \u2014 MCP server",
         "url": "https://vercel.com/docs/mcp/vercel-mcp"
       },
       {
-        "title": "Vercel Docs — REST API authentication",
+        "title": "Vercel Docs \u2014 REST API authentication",
         "url": "https://vercel.com/docs/rest-api#authentication"
       }
     ],
@@ -49,6 +49,7 @@
       "format": "openapi",
       "name": "Vercel REST API",
       "endpoint": "https://api.vercel.com",
+      "spec": "https://openapi.vercel.sh",
       "auth": "token",
       "authHeader": "Authorization: Bearer {token}",
       "docs": "https://vercel.com/docs/rest-api",

--- a/output/mcp-endpoints.json
+++ b/output/mcp-endpoints.json
@@ -1,0 +1,6220 @@
+{
+  "checkedAt": "2026-08-28T04:12:42.187Z",
+  "endpoints": {
+    "http://127.0.0.1:3000/mcp": {
+      "status": "dead",
+      "detail": "Unable to connect. Is the computer able to access the url?",
+      "checkedAt": "2026-08-28T04:12:32.413Z"
+    },
+    "http://127.0.0.1:54321/mcp": {
+      "status": "dead",
+      "detail": "Unable to connect. Is the computer able to access the url?",
+      "checkedAt": "2026-08-28T04:12:32.412Z"
+    },
+    "http://127.0.0.1:8000": {
+      "status": "dead",
+      "detail": "Unable to connect. Is the computer able to access the url?",
+      "checkedAt": "2026-08-28T04:12:32.412Z"
+    },
+    "http://127.0.0.1:8000/mcp": {
+      "status": "dead",
+      "detail": "Unable to connect. Is the computer able to access the url?",
+      "checkedAt": "2026-08-28T04:12:32.412Z"
+    },
+    "http://127.0.0.1:8288/mcp": {
+      "status": "dead",
+      "detail": "Unable to connect. Is the computer able to access the url?",
+      "checkedAt": "2026-08-28T04:12:32.412Z"
+    },
+    "http://www.kakao.golf/.well-known/mcp/server-card.json": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:32.397Z"
+    },
+    "http://www.thecompaniesapi.com/.well-known/mcp/server-card.json": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:32.387Z"
+    },
+    "https://{APP_ID}.algolia.net/mcp/1/{UNIQ_ID}/mcp": {
+      "status": "dead",
+      "detail": "Unable to connect. Is the computer able to access the url?",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://{gateway-id}.mcp-gw.frontegg.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://{region}.mcp.konghq.com/": {
+      "status": "dead",
+      "detail": "Unable to connect. Is the computer able to access the url?",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://{tenant}.chronosphere.io/api/mcp/mcp": {
+      "status": "dead",
+      "detail": "Unable to connect. Is the computer able to access the url?",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://{vanity_name}.app.visier.com/visier-query-mcp": {
+      "status": "dead",
+      "detail": "Unable to connect. Is the computer able to access the url?",
+      "checkedAt": "2026-08-28T04:12:05.032Z"
+    },
+    "https://3minapi.com/api/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:32.322Z"
+    },
+    "https://4a9466cd-e601-4d19-b90d-006c43404551.rightmove.co.uk/019bff2a-5bc6-7560-947d-b43c0152aa0a": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:32.252Z"
+    },
+    "https://4ygmimr3yj.us-east-2.awsapprunner.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:32.210Z"
+    },
+    "https://5guxfz-1n.myshopify.com/api/ucp/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:32.210Z"
+    },
+    "https://abhibus-mcp-production.abhibus-com-s-account.workers.dev/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:32.152Z"
+    },
+    "https://abroadly-ls.leapscholar.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:32.101Z"
+    },
+    "https://accessapproval.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:32.080Z"
+    },
+    "https://acheter-ou-louer-mcp.petirico.workers.dev/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:32.078Z"
+    },
+    "https://acrobat-mcp.adobe.io/mcp/call": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:32.064Z"
+    },
+    "https://adisinsight-mcp.springer.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:31.957Z"
+    },
+    "https://admin-mcp.every.ai": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:31.950Z"
+    },
+    "https://adobe-creativity.adobe.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:31.887Z"
+    },
+    "https://aep-ai-ama.adobe.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:31.876Z"
+    },
+    "https://affirmations.widgets.widget.olutely.com/affirmations/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:31.849Z"
+    },
+    "https://ag.sip.systembolaget.se/marcipan-chapp/mcp?subscription-key=7ed84209e2f44c8b83471712049c98f0": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:31.816Z"
+    },
+    "https://agent.enhancv.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:31.800Z"
+    },
+    "https://agent.thoughtspot.app/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:31.783Z"
+    },
+    "https://agentic-commerce.pinelabsonline.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:31.772Z"
+    },
+    "https://agentichoteldistribution.com/mcp/synxis?chainId=10237": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:31.756Z"
+    },
+    "https://agents.talktoglow.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:31.708Z"
+    },
+    "https://agents.yoshi.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:31.636Z"
+    },
+    "https://agentsitecms.com/mcp?shop=duceswildbbq": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:31.614Z"
+    },
+    "https://agiflow.io/api/v1/chatgpt-app/0.0.1": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:31.548Z"
+    },
+    "https://agreezone.replit.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:31.537Z"
+    },
+    "https://ah-api.merge.dev/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:31.501Z"
+    },
+    "https://ai-agents.infra.updatron.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:31.496Z"
+    },
+    "https://ai-analytics-mcp.kraken.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:31.484Z"
+    },
+    "https://ai-connect.norton.com/api/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:31.474Z"
+    },
+    "https://ai-inc.mailchimp.com/claude/mcp/v2": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:31.438Z"
+    },
+    "https://ai-inc.quickbooks.intuit.com/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:31.420Z"
+    },
+    "https://ai-inc.turbotax.intuit.com/358A1C1B-F73B-46A7-B130-4B14916E6843/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:31.360Z"
+    },
+    "https://ai-stats.phaseo.app/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:31.330Z"
+    },
+    "https://ai-toolkit.mountaingoatsoftware.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:31.300Z"
+    },
+    "https://ai.boleron.bg/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:31.245Z"
+    },
+    "https://ai.carfax.com/v2/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:31.189Z"
+    },
+    "https://ai.chronograph.pe/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:31.166Z"
+    },
+    "https://ai.despegar.io/odyssey/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:31.164Z"
+    },
+    "https://ai.monito.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:31.051Z"
+    },
+    "https://ai.simsurf.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:31.047Z"
+    },
+    "https://ai.thirdbridge.com/mcp/sse": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:31.043Z"
+    },
+    "https://ai.todoist.net/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:31.025Z"
+    },
+    "https://ai.tourradar.com/mcp/main": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:30.973Z"
+    },
+    "https://ai.vancompare.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:30.946Z"
+    },
+    "https://ai.vroomvroomvroom.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:30.937Z"
+    },
+    "https://aihub.semparar.com.br/gptappmcp-prd/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:30.932Z"
+    },
+    "https://aios.dewa.gov.ae/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:30.902Z"
+    },
+    "https://ajo-mcp.adobe.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.885Z"
+    },
+    "https://akqa-emea-starbucks-chatgpt-app.vercel.app/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:30.868Z"
+    },
+    "https://alf-rehn.mcp.noodleseed.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:30.851Z"
+    },
+    "https://all-ten-chat-gpt-app.replit.app/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:30.849Z"
+    },
+    "https://alpcoind.mcp.noodleseed.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:30.841Z"
+    },
+    "https://analyticsadmin.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:30.784Z"
+    },
+    "https://androidmanagement.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:30.776Z"
+    },
+    "https://angleradventures.tapteach.org/mcpServer": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:30.775Z"
+    },
+    "https://anthropic.mcp.creditkarma.com/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 200, no initialize result",
+      "checkedAt": "2026-08-28T04:12:30.769Z"
+    },
+    "https://api-hub.localiza.com/genaichatapp-mcp/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:30.759Z"
+    },
+    "https://api-mcp.computrabajo.com": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:30.698Z"
+    },
+    "https://api-ssl.bitly.com/v4/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.646Z"
+    },
+    "https://api-staging.letsdeel.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:30.626Z"
+    },
+    "https://api.advancedwebranking.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.610Z"
+    },
+    "https://api.ahrefs.com/mcp/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.596Z"
+    },
+    "https://api.analytics.lseg.com/lfa/mcp/server-cl": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.578Z"
+    },
+    "https://api.angi.com/v1/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:30.556Z"
+    },
+    "https://api.appdeploy.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.530Z"
+    },
+    "https://api.arcjet.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.527Z"
+    },
+    "https://api.braintrust.dev/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.519Z"
+    },
+    "https://api.brex.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.514Z"
+    },
+    "https://api.browser-use.com/v3/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:30.482Z"
+    },
+    "https://api.capacities.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.466Z"
+    },
+    "https://api.cardchain.ai/mcp/chatgpt": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:30.429Z"
+    },
+    "https://api.checkatrade.com/v1/chatgpt-mcp-server/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:30.387Z"
+    },
+    "https://api.checklyhq.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.364Z"
+    },
+    "https://api.clarify.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.325Z"
+    },
+    "https://api.clarivate.com/lifesciences/mcp-regulatory/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.315Z"
+    },
+    "https://api.clay.com/v3/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.311Z"
+    },
+    "https://api.cobaltpf.com/api/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.305Z"
+    },
+    "https://api.contentsquare.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.278Z"
+    },
+    "https://api.corrently.io/v2.0/mcp/tools": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:30.268Z"
+    },
+    "https://api.dashboard.plaid.com/mcp/sse": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.257Z"
+    },
+    "https://api.dataplatform.cloud.ibm.com/wxbi/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.241Z"
+    },
+    "https://api.deals-gpt.loudcrowd.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:30.238Z"
+    },
+    "https://api.devrev.ai/mcp/v1": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.216Z"
+    },
+    "https://api.digits.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.192Z"
+    },
+    "https://api.driftless.icu/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.188Z"
+    },
+    "https://api.edge.content-mcp-server.prod.bodi.com/gpt-app/mcp": {
+      "status": "unknown",
+      "detail": "The operation timed out.",
+      "checkedAt": "2026-08-28T04:12:30.181Z"
+    },
+    "https://api.factagora.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.150Z"
+    },
+    "https://api.fathom.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.119Z"
+    },
+    "https://api.fireflies.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.116Z"
+    },
+    "https://api.fiscal.ai/mcp/sse": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.105Z"
+    },
+    "https://api.fullstory.com/mcp/fullstory": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.092Z"
+    },
+    "https://api.galileo.ai/mcp/http/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:30.062Z"
+    },
+    "https://api.gateway.wizehire.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.022Z"
+    },
+    "https://api.githubcopilot.com/mcp/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:30.014Z"
+    },
+    "https://api.godaddy.com/v1/domains/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:30.014Z"
+    },
+    "https://api.gptapps-aws.follett.com/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:30.002Z"
+    },
+    "https://api.grain.com/_/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.989Z"
+    },
+    "https://api.greptile.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:29.921Z"
+    },
+    "https://api.harvey.ai/hosted_mcp/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.910Z"
+    },
+    "https://api.healthex.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.897Z"
+    },
+    "https://api.heffl.com/api/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.867Z"
+    },
+    "https://api.hindsight.vectorize.io/mcp/{bank_id}/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.854Z"
+    },
+    "https://api.hyperping.io/v1/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:29.848Z"
+    },
+    "https://api.introvoke.com/api/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.844Z"
+    },
+    "https://api.itsdunzo.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:29.829Z"
+    },
+    "https://api.ixigo.com/bridgeai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:29.791Z"
+    },
+    "https://api.jars.lt/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:29.775Z"
+    },
+    "https://api.jentic.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:29.774Z"
+    },
+    "https://api.jora.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.761Z"
+    },
+    "https://api.kestra.io/v1/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:29.721Z"
+    },
+    "https://api.krikey.ai/openai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:29.709Z"
+    },
+    "https://api.kubera.com/api/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.646Z"
+    },
+    "https://api.lmnr.ai/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.633Z"
+    },
+    "https://api.lorikeetcx.ai/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.624Z"
+    },
+    "https://api.lovable.dev/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.612Z"
+    },
+    "https://api.lugg.com/mcp/public": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:29.567Z"
+    },
+    "https://api.luxuryescapes.com/api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:29.509Z"
+    },
+    "https://api.magneto365.com/agents/v1/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:29.494Z"
+    },
+    "https://api.meetcampfire.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.490Z"
+    },
+    "https://api.mercuryinsurance.com/api/ai-quote-tools/v1/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:29.479Z"
+    },
+    "https://api.mirai.com/synapse/mcp?hotelId=10030559": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:29.385Z"
+    },
+    "https://api.monoscope.tech/api/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.260Z"
+    },
+    "https://api.moodtrip.ai/api/mcp-http": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:29.245Z"
+    },
+    "https://api.moodys.com/genai-ready-data/m1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.228Z"
+    },
+    "https://api.motherduck.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.214Z"
+    },
+    "https://api.motionhub.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.209Z"
+    },
+    "https://api.openbudget.sh/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.161Z"
+    },
+    "https://api.opencapital.sh/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.158Z"
+    },
+    "https://api.openobserve.ai/api/default/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.147Z"
+    },
+    "https://api.openstatus.dev/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.088Z"
+    },
+    "https://api.optionscalc.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:29.034Z"
+    },
+    "https://api.originalvoices.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.025Z"
+    },
+    "https://api.outreach.io/mcp/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:29.022Z"
+    },
+    "https://api.pcexpress.ca/v1/agents/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:29.020Z"
+    },
+    "https://api.pdfmaker.to/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:28.992Z"
+    },
+    "https://api.peec.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:28.985Z"
+    },
+    "https://api.printhiv3d.com/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:28.953Z"
+    },
+    "https://api.production.neighbor.com/mcp-server/discovery/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:28.941Z"
+    },
+    "https://api.quizlet.com/v4/partner/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:28.912Z"
+    },
+    "https://api.read.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:28.908Z"
+    },
+    "https://api.redoxengine.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:28.865Z"
+    },
+    "https://api.rillet.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:28.865Z"
+    },
+    "https://api.roadops.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:28.821Z"
+    },
+    "https://api.scite.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:28.792Z"
+    },
+    "https://api.sierra.chat/chat/_UjgWN4Bl-YJFsMBmn6VXROTPHGXRd9NCk5oWwSqMMA/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:28.758Z"
+    },
+    "https://api.sierra.chat/chat/EjQq6tcBmBR3J0kBmyP2dwIhGdGDuOpdcINADkeE94Q/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:28.776Z"
+    },
+    "https://api.sierra.chat/chat/fiKQF58BmL5HCdwBmn5G6nFeM9kSoKWMZNLoDRD1b8Q/mcp/GPT-1-1": {
+      "status": "unknown",
+      "detail": "HTTP 400",
+      "checkedAt": "2026-08-28T04:12:28.735Z"
+    },
+    "https://api.sketchup.com/mcp/v1/sketchup/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:28.726Z"
+    },
+    "https://api.skywatch.co/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:28.706Z"
+    },
+    "https://api.sparkspot.be/mcp/public/parkingspots": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:28.680Z"
+    },
+    "https://api.stablebaseline.io/functions/v1/cloud-serve/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:28.680Z"
+    },
+    "https://api.statsig.com/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:28.676Z"
+    },
+    "https://api.streak.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:28.676Z"
+    },
+    "https://api.sumsub.com/mcp/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:28.671Z"
+    },
+    "https://api.tally.so/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:28.661Z"
+    },
+    "https://api.tomorrow.io/v4/weather-apps/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:28.656Z"
+    },
+    "https://api.tray.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:28.642Z"
+    },
+    "https://api.udemy.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:28.558Z"
+    },
+    "https://api.udemy.com/mcp-chatgpt/2025-10": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:28.534Z"
+    },
+    "https://api.vybit.net/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:28.530Z"
+    },
+    "https://api.whack.ie/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 502",
+      "checkedAt": "2026-08-28T04:12:28.514Z"
+    },
+    "https://api.ww.com/ai/mcp-openai-glp1-recipes/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:28.439Z"
+    },
+    "https://api.x.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:28.432Z"
+    },
+    "https://api.ziprecruiter.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:28.400Z"
+    },
+    "https://api2.jebbit.com/mcp/open_ai": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:28.388Z"
+    },
+    "https://api2.transloadit.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:28.385Z"
+    },
+    "https://apigee.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:28.298Z"
+    },
+    "https://apigw.americanexpress.com/dining/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:28.298Z"
+    },
+    "https://apim.carmax.com/chatgpt-connector/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:28.294Z"
+    },
+    "https://apimanagement.cazoo.co.uk/chat-gpt-app/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:28.216Z"
+    },
+    "https://apis.despegar.com/api-b2b-flights-mcp/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:28.209Z"
+    },
+    "https://app-chatgpt.idealista.com/idealista/chatgpt/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:28.206Z"
+    },
+    "https://app-mcp-mobile.leparisien.fr/_mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:28.204Z"
+    },
+    "https://app-mcp.invideo.io": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:28.139Z"
+    },
+    "https://app-sdk.sweetspotgov.workers.dev/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:28.127Z"
+    },
+    "https://app.airops.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:28.024Z"
+    },
+    "https://app.base44.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:27.999Z"
+    },
+    "https://app.book-direct.co/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:27.996Z"
+    },
+    "https://app.caloriegptapp.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:27.959Z"
+    },
+    "https://app.chatgpt.immobilienscout24.de/v2/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:27.957Z"
+    },
+    "https://app.circleback.ai/api/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:27.890Z"
+    },
+    "https://app.closai.io/mcp/v2": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:27.868Z"
+    },
+    "https://app.docsie.io/mcp/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:27.863Z"
+    },
+    "https://app.flarehawk.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:27.857Z"
+    },
+    "https://app.fullstackgtm.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:27.837Z"
+    },
+    "https://app.hex.tech/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:27.816Z"
+    },
+    "https://app.ketryx.com/api/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:27.816Z"
+    },
+    "https://app.lemlist.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:27.790Z"
+    },
+    "https://app.merano.eu/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:27.780Z"
+    },
+    "https://app.midpage.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:27.759Z"
+    },
+    "https://app.mintmcp.com/s/{server_id}/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:27.715Z"
+    },
+    "https://app.mydeetz.ai/api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:27.702Z"
+    },
+    "https://app.nexafin.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:27.682Z"
+    },
+    "https://app.pendo.io/mcp/v0/shttp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:27.635Z"
+    },
+    "https://app.quiver.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:27.627Z"
+    },
+    "https://app.ranked.ai/api/mcp/sse": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:27.617Z"
+    },
+    "https://app.reagent.travel/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:27.610Z"
+    },
+    "https://app.refiner.io/v001/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:27.591Z"
+    },
+    "https://app.rfpio.com/oa/v2/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:27.574Z"
+    },
+    "https://app.tropicapp.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:27.569Z"
+    },
+    "https://app.unthread.io/api/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:27.558Z"
+    },
+    "https://app.windmill.dev/api/mcp/gateway": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:27.547Z"
+    },
+    "https://apt-scout.greystar.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:27.517Z"
+    },
+    "https://aris.kongmy.dev/": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:27.507Z"
+    },
+    "https://artue.io/api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:27.406Z"
+    },
+    "https://asset-management.mcp.cloudinary.com/sse": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:27.355Z"
+    },
+    "https://atc-chatgpt-app-prod.awsfyc.autotrader.com/mcp/messages": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:27.312Z"
+    },
+    "https://atlas.live.acko.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:27.306Z"
+    },
+    "https://auto-calculator.onrender.com/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:27.294Z"
+    },
+    "https://automotion-mcp-production-6f08e98a6e4b.herokuapp.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:27.289Z"
+    },
+    "https://avi.avalara.com/a2a/avi": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:27.174Z"
+    },
+    "https://aviator.headout.com/mcp/": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:27.174Z"
+    },
+    "https://b12.io/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:27.150Z"
+    },
+    "https://backend.app.microverselabs.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:27.066Z"
+    },
+    "https://backend.clidrive.com/intelligence/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:27.062Z"
+    },
+    "https://backend.composio.dev/v3/mcp/YOUR_SERVER_ID?user_id=YOUR_USER_ID": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:27.058Z"
+    },
+    "https://backend.getmedesign.com/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 200, no initialize result",
+      "checkedAt": "2026-08-28T04:12:27.042Z"
+    },
+    "https://backend.otseek.com/mcp": {
+      "status": "dead",
+      "detail": "Unable to connect. Is the computer able to access the url?",
+      "checkedAt": "2026-08-28T04:12:27.009Z"
+    },
+    "https://bananabee.mcp.noodleseed.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.994Z"
+    },
+    "https://bananagen.awesomize.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.986Z"
+    },
+    "https://bankrate-openai-mcp.bankrate.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.962Z"
+    },
+    "https://barcelo-mcp.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:26.926Z"
+    },
+    "https://basbas.mcp.noodleseed.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.881Z"
+    },
+    "https://bbnmcp.cfdomains.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.880Z"
+    },
+    "https://be.skipcalls.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:26.875Z"
+    },
+    "https://beamcpserverprod.flaerobotics.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.861Z"
+    },
+    "https://benefits-mcp.playdigital.com.ar/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.854Z"
+    },
+    "https://betterstack.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:26.836Z"
+    },
+    "https://bible-verse.widgets.widget.olutely.com/bible-verse/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.832Z"
+    },
+    "https://bigquery.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.779Z"
+    },
+    "https://bigquerydatatransfer.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.760Z"
+    },
+    "https://bigtableadmin.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.758Z"
+    },
+    "https://billingbudgets.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.755Z"
+    },
+    "https://billpay-mcp.setu.co/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:26.712Z"
+    },
+    "https://bindings.mcp.cloudflare.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:26.664Z"
+    },
+    "https://bixby.prod.walmart.com/v1/client/oai/tenant/walmart-us/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.662Z"
+    },
+    "https://bizify-mcp.bizcover.com.au/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:26.657Z"
+    },
+    "https://body-health-calculator.onrender.com/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:26.644Z"
+    },
+    "https://booking.amapas353.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.596Z"
+    },
+    "https://bot.clutch.co/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.575Z"
+    },
+    "https://botgpt.botpress.sh/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:26.573Z"
+    },
+    "https://box.main-kill-isr.mintlify.me/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.563Z"
+    },
+    "https://bpcs-gptapp.bpcs-ad-broker.de/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.563Z"
+    },
+    "https://buf.build/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:26.423Z"
+    },
+    "https://buildwithfern.com/learn/_mcp/server": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.402Z"
+    },
+    "https://c-com.mcp.noodleseed.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.388Z"
+    },
+    "https://calculator.widgets.widget.olutely.com/calculator/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.386Z"
+    },
+    "https://calendar.widgets.widget.olutely.com/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 502",
+      "checkedAt": "2026-08-28T04:12:26.343Z"
+    },
+    "https://callbacks.omniapp.co/callback/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:26.321Z"
+    },
+    "https://calorieappguide.com/.well-known/mcp/server-card.json": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:26.312Z"
+    },
+    "https://calorieappguidemcp-production.up.railway.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.305Z"
+    },
+    "https://candidhealth.com/.well-known/mcp/server-card.json": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:26.281Z"
+    },
+    "https://canny.io/api/mcp/v1": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:26.278Z"
+    },
+    "https://captainpeter-gptapp.centralus.prod.maersk.io/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.230Z"
+    },
+    "https://carb.suri.cz/api/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:26.200Z"
+    },
+    "https://carrier-inventory.mediaalpha.com/openai-app-autoinsurance/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.198Z"
+    },
+    "https://chat-gpt-app.api.cargurus.com/chat-mcp/v1/stream": {
+      "status": "unknown",
+      "detail": "HTTP 400",
+      "checkedAt": "2026-08-28T04:12:26.187Z"
+    },
+    "https://chat-mcp-openai-app.production.linktr.ee/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.139Z"
+    },
+    "https://chat.teklifimgelsin.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.097Z"
+    },
+    "https://chat.trustoo.nl/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.075Z"
+    },
+    "https://chatestate.realestate.com.au/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:26.074Z"
+    },
+    "https://chatgpt-api.insighttimer-api.net/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.070Z"
+    },
+    "https://chatgpt-app-server.tourlane.wl.lambus.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.047Z"
+    },
+    "https://chatgpt-app-with-next-js-t66k.vercel.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.026Z"
+    },
+    "https://chatgpt-app.evaneos.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:26.019Z"
+    },
+    "https://chatgpt-app.hemnet.workers.dev/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.915Z"
+    },
+    "https://chatgpt-app.meetup.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.902Z"
+    },
+    "https://chatgpt-app.printify.com/mcp-personalized-gifts-for-chatgpt": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.902Z"
+    },
+    "https://chatgpt-app.retellai.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.874Z"
+    },
+    "https://chatgpt-app.rome2rio.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:25.861Z"
+    },
+    "https://chatgpt-app.seatgeek.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.859Z"
+    },
+    "https://chatgpt-app.seatunique.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:25.841Z"
+    },
+    "https://chatgpt-app.smallpdf.com/sse": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:25.829Z"
+    },
+    "https://chatgpt-app.von-poll.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.820Z"
+    },
+    "https://chatgpt-app.wednesday.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.800Z"
+    },
+    "https://chatgpt-imovirtual.genai.olx.io/": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.794Z"
+    },
+    "https://chatgpt-mcp.boxoffice.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:25.725Z"
+    },
+    "https://chatgpt-mcp.jooble.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.725Z"
+    },
+    "https://chatgpt-recipe-app.production.raptive.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.681Z"
+    },
+    "https://chatgpt.airport-pickups-london.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.653Z"
+    },
+    "https://chatgpt.almosafer.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.614Z"
+    },
+    "https://chatgpt.blazesql.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:25.559Z"
+    },
+    "https://chatgpt.bot.check24.de/v4.0/mcp/stream": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:25.554Z"
+    },
+    "https://chatgpt.cruisecritic.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.535Z"
+    },
+    "https://chatgpt.enzoreader.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:25.524Z"
+    },
+    "https://chatgpt.mcp.thetrainline.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:25.512Z"
+    },
+    "https://chatgpt.mermaid.ai/anthropic/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.446Z"
+    },
+    "https://chatgpt.newt.net/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.417Z"
+    },
+    "https://chatgpt.nutrimindz.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.351Z"
+    },
+    "https://chatgpt.privatemdlabs.com/mcp/privatemdlabs/c3e4b1a9-7f2a-4d8e-b6c9-91f4e0a2d5b7": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.300Z"
+    },
+    "https://chatgpt.promptperfect.xyz/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:25.300Z"
+    },
+    "https://chatgpt.sleepcycle.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.298Z"
+    },
+    "https://chatgpt.smartcustomer.com/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 502",
+      "checkedAt": "2026-08-28T04:12:25.255Z"
+    },
+    "https://chatgpt.trademeai.co.nz/api/v1/gateways/chatgpt/apps/trademe-property/v0.12/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.221Z"
+    },
+    "https://chatgpt.zumper.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.219Z"
+    },
+    "https://chatgptapp-me-twalton.secure-cdn.meg-eu.accessoticketing.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.207Z"
+    },
+    "https://chatgptcompanion.gateway.api.mcafee.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:25.158Z"
+    },
+    "https://chatgptmcpzip.replit.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.150Z"
+    },
+    "https://cheat-database.com/mcp-server/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.082Z"
+    },
+    "https://chess.altmatter.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.065Z"
+    },
+    "https://chess.widgets.widget.olutely.com/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 502",
+      "checkedAt": "2026-08-28T04:12:25.050Z"
+    },
+    "https://ckan-mcp-server.andy-pr.workers.dev/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.019Z"
+    },
+    "https://clarity-method.mcp.noodleseed.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:25.005Z"
+    },
+    "https://clarity-sfdr20-mcp.pro.clarity.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.999Z"
+    },
+    "https://claude-mcp-api.ml.goodnotes.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.996Z"
+    },
+    "https://clock.widgets.widget.olutely.com/clock/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.964Z"
+    },
+    "https://cloud.langfuse.com/api/public/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:24.953Z"
+    },
+    "https://cloud.yepcode.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:24.951Z"
+    },
+    "https://cloudasset.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.905Z"
+    },
+    "https://clouderrorreporting.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.875Z"
+    },
+    "https://cloudresourcemanager.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.821Z"
+    },
+    "https://cloudsupport.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.815Z"
+    },
+    "https://cloudtrace.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.791Z"
+    },
+    "https://cmcp.shop/mcp/e4b5ec4f-6e83-4292-b7c5-32272974d287": {
+      "status": "dead",
+      "detail": "Unable to connect. Is the computer able to access the url?",
+      "checkedAt": "2026-08-28T04:12:24.787Z"
+    },
+    "https://cockroachlabs.cloud/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:24.787Z"
+    },
+    "https://color-picker.widgets.widget.olutely.com/color-picker/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.772Z"
+    },
+    "https://commerce-api.newegg.com/openai/mcp/chatgpt-newegg-app": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.757Z"
+    },
+    "https://compute.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.752Z"
+    },
+    "https://connect.shopback.com/shopbackgpt/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.743Z"
+    },
+    "https://connect.squareup.com/v2/mcp/cash-app": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.724Z"
+    },
+    "https://connect.thehotelsnetwork.com/v2/mcp/hub": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:24.705Z"
+    },
+    "https://connector.scholargateway.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:24.703Z"
+    },
+    "https://contactcenterinsights.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.629Z"
+    },
+    "https://container.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.616Z"
+    },
+    "https://context-dev.stlmcp.com": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.612Z"
+    },
+    "https://contract-check.petprojectcofounder.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.549Z"
+    },
+    "https://contribution-calculator.bestsolo401k.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.521Z"
+    },
+    "https://conversation.widgets.widget.olutely.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.517Z"
+    },
+    "https://copilot.fintual.com/mcp/": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.403Z"
+    },
+    "https://cortenoi-mcp-299405366082.europe-west1.run.app/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 503",
+      "checkedAt": "2026-08-28T04:12:24.401Z"
+    },
+    "https://cortenoi-mcp-drmpaogcjq-ew.a.run.app/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 500",
+      "checkedAt": "2026-08-28T04:12:24.383Z"
+    },
+    "https://coupons.widgets.widget.olutely.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.381Z"
+    },
+    "https://cowboy-model-finder-mcp-app-8b3709a7529a.herokuapp.com/sse": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:24.373Z"
+    },
+    "https://crbonfree-mcp-server.vercel.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.339Z"
+    },
+    "https://createstate.ai/chatgpt/sse": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:24.298Z"
+    },
+    "https://creed.md/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:24.291Z"
+    },
+    "https://crewai.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.178Z"
+    },
+    "https://crossword.widgets.widget.olutely.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.166Z"
+    },
+    "https://cvpop-mcp-server.fly.dev/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.164Z"
+    },
+    "https://cx-mcp.virginatlantic.com/mcp": {
+      "status": "unknown",
+      "detail": "The operation timed out.",
+      "checkedAt": "2026-08-28T04:12:24.135Z"
+    },
+    "https://d2p3kt79hdhtiu.cloudfront.net/sse": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:24.130Z"
+    },
+    "https://data-search.apigw.feverup.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:24.123Z"
+    },
+    "https://data.policynote.com/v0/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:24.105Z"
+    },
+    "https://dataaccess.adb.{region-identifier}.oraclecloudapps.com/adb/mcp/v1/databases/{database-ocid}": {
+      "status": "dead",
+      "detail": "Unable to connect. Is the computer able to access the url?",
+      "checkedAt": "2026-08-28T04:12:24.089Z"
+    },
+    "https://datacamp-mcp.datacamp.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.082Z"
+    },
+    "https://dataflow.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.080Z"
+    },
+    "https://dataplex.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.047Z"
+    },
+    "https://dataproc.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.039Z"
+    },
+    "https://datastream.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:24.029Z"
+    },
+    "https://day.ai/api/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:23.982Z"
+    },
+    "https://degreeplanner.straighterline.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.978Z"
+    },
+    "https://demandapi-mcp.booking.com/v1/mcp/8132308": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:23.967Z"
+    },
+    "https://dev.craime.se/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.965Z"
+    },
+    "https://dev.gosure.ai/core-mcp/api": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.954Z"
+    },
+    "https://developer.api.autodesk.com/knowledge/public/v1/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.938Z"
+    },
+    "https://developer.mozilla.org/api/v1/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:23.925Z"
+    },
+    "https://developer.spreedly.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.917Z"
+    },
+    "https://developers.bump.sh/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.907Z"
+    },
+    "https://developers.deepgram.com/_mcp/server": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.894Z"
+    },
+    "https://developers.glean.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.873Z"
+    },
+    "https://developers.hellosign.com/_mcp/server": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.859Z"
+    },
+    "https://developers.kit.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.845Z"
+    },
+    "https://developers.llamaindex.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.815Z"
+    },
+    "https://developers.rentcast.io/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.809Z"
+    },
+    "https://developers.smtp2go.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.805Z"
+    },
+    "https://dialogflow.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.747Z"
+    },
+    "https://dictionary.widgets.widget.olutely.com/dictionary/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.714Z"
+    },
+    "https://docs-mcp.getzep.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.702Z"
+    },
+    "https://docuseal.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:23.675Z"
+    },
+    "https://dog-breeds.widgets.widget.olutely.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.662Z"
+    },
+    "https://doodle.widgets.widget.olutely.com/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 502",
+      "checkedAt": "2026-08-28T04:12:23.588Z"
+    },
+    "https://dovetail.com/api/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:23.569Z"
+    },
+    "https://e2b.dev/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.562Z"
+    },
+    "https://edge.ballparkhq.com/api/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:23.562Z"
+    },
+    "https://edge.upwork.com/api/v4/upw-chatgpt-app/mcp/": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.559Z"
+    },
+    "https://eg.ethoslife.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.557Z"
+    },
+    "https://email-creation-mcp-node-production.up.railway.app/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:23.495Z"
+    },
+    "https://emt-mcp-server.easemytrip.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.475Z"
+    },
+    "https://enechange.jp/api/apps_in_chatgpt/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:23.454Z"
+    },
+    "https://estimator-mcp.justfix.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.450Z"
+    },
+    "https://evo.fintables.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:23.421Z"
+    },
+    "https://example-server.modelcontextprotocol.io/sheet-music/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.416Z"
+    },
+    "https://example-server.modelcontextprotocol.io/threejs/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.412Z"
+    },
+    "https://executor.sh/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:23.402Z"
+    },
+    "https://exp-app-mcp.prod.ep.viator.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.400Z"
+    },
+    "https://express-mcp-service.adobe.io/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.363Z"
+    },
+    "https://external-agent-mcp.ctmers.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:23.344Z"
+    },
+    "https://external-mcp-service.quintoandar.com.br/mcp-server/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.313Z"
+    },
+    "https://fact.widgets.widget.olutely.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.308Z"
+    },
+    "https://factiva.mcp.shared-data.dowjones.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:23.266Z"
+    },
+    "https://fellow.app/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:23.186Z"
+    },
+    "https://fgdsp698b0.execute-api.eu-west-1.amazonaws.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.178Z"
+    },
+    "https://fids-mcp.ice.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:23.165Z"
+    },
+    "https://fig-mcp.instacart.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:23.164Z"
+    },
+    "https://filar-szumlanski-zachara.mcp.noodleseed.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.161Z"
+    },
+    "https://file.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.107Z"
+    },
+    "https://financialmodelingprep.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:23.041Z"
+    },
+    "https://firestore.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.023Z"
+    },
+    "https://flixor.toolpipe.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:23.012Z"
+    },
+    "https://flower-delivery-ffh2.onrender.com/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:22.998Z"
+    },
+    "https://fontgpt-chatgpt.monotype.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.990Z"
+    },
+    "https://football.widgets.widget.olutely.com/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 502",
+      "checkedAt": "2026-08-28T04:12:22.960Z"
+    },
+    "https://forex.widgets.widget.olutely.com/forex/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.951Z"
+    },
+    "https://formbyte.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.923Z"
+    },
+    "https://formulagenius.co/sse": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:22.867Z"
+    },
+    "https://framagit.org/api/v4/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:22.860Z"
+    },
+    "https://fullstackgtm.com": {
+      "status": "unknown",
+      "detail": "HTTP 405",
+      "checkedAt": "2026-08-28T04:12:22.856Z"
+    },
+    "https://g.runorion.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:22.835Z"
+    },
+    "https://gailo-halloran.mcp.noodleseed.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.800Z"
+    },
+    "https://garchi.co.uk/mcp-oauth": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:22.798Z"
+    },
+    "https://gateway.demandbase.com/mcp/servers/db-mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:22.757Z"
+    },
+    "https://gateway.kleinanzeigen.de/openai-app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.651Z"
+    },
+    "https://gathrd.uk/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:22.626Z"
+    },
+    "https://gitmcp.io/{owner}/{repo}": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.605Z"
+    },
+    "https://glossary.widgets.widget.olutely.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.598Z"
+    },
+    "https://go-to-appraiser.mcp.noodleseed.com/mcp": {
+      "status": "dead",
+      "detail": "HTTP 410",
+      "checkedAt": "2026-08-28T04:12:22.588Z"
+    },
+    "https://go.kone.vc/business": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.587Z"
+    },
+    "https://gogs.io/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.585Z"
+    },
+    "https://govcon.dev/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:22.576Z"
+    },
+    "https://govtribe.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:22.572Z"
+    },
+    "https://gpt-api.loft.com.br/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.558Z"
+    },
+    "https://gpt-in-app.apddev.com/": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.525Z"
+    },
+    "https://gpt-mcp.service.spaceship.com/mcp/": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:22.516Z"
+    },
+    "https://gpt-namecheap-mcp.service.spaceship.com/mcp/": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:22.493Z"
+    },
+    "https://gpt.bestcolleges.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.492Z"
+    },
+    "https://gpt.main.komoot.net/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.492Z"
+    },
+    "https://gpt.subscriptionflow.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.489Z"
+    },
+    "https://gptapp.sonicapply.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.450Z"
+    },
+    "https://gptconnector.promocodes.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.446Z"
+    },
+    "https://grantedai.com/api/mcp/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.444Z"
+    },
+    "https://gs-plant-foods.mcp.noodleseed.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.423Z"
+    },
+    "https://gsplantfoods.com/api/ucp/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.404Z"
+    },
+    "https://gt-api.gumtree.com.au/partner/mcp/39cc77d5c8ae755375b92dfaf4d9ce072fe5a8692f1ea1804e254a88945d225c/": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.368Z"
+    },
+    "https://h10-mcp-chatgptapps.pacvue.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:22.349Z"
+    },
+    "https://happenstance.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:22.330Z"
+    },
+    "https://hauptsache.net/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:22.330Z"
+    },
+    "https://help.sigmacomputing.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.311Z"
+    },
+    "https://hercules.app/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:22.290Z"
+    },
+    "https://hibbett.mcp.optiversal.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.284Z"
+    },
+    "https://hjarni.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:22.269Z"
+    },
+    "https://hmcp.hostinger.com/chatgpt/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:22.253Z"
+    },
+    "https://homegraph.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.235Z"
+    },
+    "https://horoscopes.widgets.widget.olutely.com/horoscopes/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.233Z"
+    },
+    "https://houstonian.com/.well-known/agent-card.json": {
+      "status": "unknown",
+      "detail": "HTTP 200, no initialize result",
+      "checkedAt": "2026-08-28T04:12:22.219Z"
+    },
+    "https://huggingface.co/mcp?login&gradio=none": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:22.176Z"
+    },
+    "https://ia-openai-prd.ecsbr.net/mcp/": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:22.157Z"
+    },
+    "https://idealo-app-in-chatgpt.idealo.tools/v5/mcp/": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:22.145Z"
+    },
+    "https://ifttt.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:22.133Z"
+    },
+    "https://immobilier.lefigaro.fr/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.104Z"
+    },
+    "https://integrations.freediver.club/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:22.099Z"
+    },
+    "https://integrations.profit.co/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:22.092Z"
+    },
+    "https://integrations.sh/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:22.029Z"
+    },
+    "https://investment-calculator-1a2t.onrender.com/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:22.028Z"
+    },
+    "https://inviton-gpt-mcp.yellowocean-74d7a25f.westeurope.azurecontainerapps.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:22.013Z"
+    },
+    "https://jerry.ai/api/chatgpt-apps-jerry/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.973Z"
+    },
+    "https://jettly.mcp.noodleseed.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.970Z"
+    },
+    "https://jitty.com/mcp/openai": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.934Z"
+    },
+    "https://jn4hi3zv94.execute-api.us-east-1.amazonaws.com/sse": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.911Z"
+    },
+    "https://johns-hopkins-gpt-app.sonicapply.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.889Z"
+    },
+    "https://kbb-chatgpt-app-prod-a.awskbbcs.kbb.com/mcp/messages": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:21.875Z"
+    },
+    "https://keybid.eu/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.872Z"
+    },
+    "https://kfinance.kensho.com/integrations/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:21.846Z"
+    },
+    "https://kg.mcp.learningcommons.org/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:21.822Z"
+    },
+    "https://kindora-mcp.azurewebsites.net/mcp/": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.820Z"
+    },
+    "https://knowledge-graph.chatgptapps.sider.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:21.787Z"
+    },
+    "https://kokiko.idoctor.md/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.750Z"
+    },
+    "https://kredit.ae/api/mcp/sse": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:21.724Z"
+    },
+    "https://kronan.is/api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.709Z"
+    },
+    "https://kyiv-gallery.mcp.noodleseed.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.704Z"
+    },
+    "https://labs-api.colossyan.com/api/assessment/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.702Z"
+    },
+    "https://lambus.com/.well-known/mcp/server-card.json": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:21.687Z"
+    },
+    "https://learn.microsoft.com/api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.669Z"
+    },
+    "https://lesson-plan.widgets.widget.olutely.com/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 502",
+      "checkedAt": "2026-08-28T04:12:21.645Z"
+    },
+    "https://level2labs-prod--adm-mcp-audio-serve.modal.run/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.581Z"
+    },
+    "https://leyware-mcp.vercel.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.561Z"
+    },
+    "https://links.widgets.widget.olutely.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.555Z"
+    },
+    "https://litellm-api.up.railway.app/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 500",
+      "checkedAt": "2026-08-28T04:12:21.545Z"
+    },
+    "https://ll-mcp.replit.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.543Z"
+    },
+    "https://llm-apps.omio.ai/chatgpt": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:21.526Z"
+    },
+    "https://llms-apps.gw.coches.net/coches/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.506Z"
+    },
+    "https://llms-apps.gw.coches.net/milanuncios/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.500Z"
+    },
+    "https://llms-apps.gw.coches.net/motos/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.486Z"
+    },
+    "https://lobehub.com/.well-known/mcp/server-card.json": {
+      "status": "unknown",
+      "detail": "HTTP 405",
+      "checkedAt": "2026-08-28T04:12:21.485Z"
+    },
+    "https://logging.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.454Z"
+    },
+    "https://london-underground.widgets.widget.olutely.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.446Z"
+    },
+    "https://lottery.widgets.widget.olutely.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.427Z"
+    },
+    "https://lovelymango-zzaim-mcp.hf.space/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.409Z"
+    },
+    "https://lucid-developer-docs.readme.io/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.409Z"
+    },
+    "https://lunarcrush.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.386Z"
+    },
+    "https://mainfunc.ai/.well-known/mcp/server-card.json": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:21.377Z"
+    },
+    "https://makerbak3d.mcp.noodleseed.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.372Z"
+    },
+    "https://mandrillapp.com/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 200, no initialize result",
+      "checkedAt": "2026-08-28T04:12:21.364Z"
+    },
+    "https://mangaboom.awesomize.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.364Z"
+    },
+    "https://mapify.so/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:21.344Z"
+    },
+    "https://marketplace-mcp.us-east-1.api.aws/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.273Z"
+    },
+    "https://masbasbas.com/api/ucp/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.271Z"
+    },
+    "https://master.mcp-openai.evoyageurs.prod.cdn.vsct.fr/message": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:21.269Z"
+    },
+    "https://mcp-{REGION}.hygraph.com/{PROJECT_ID}/{ENVIRONMENT}/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 400",
+      "checkedAt": "2026-08-28T04:12:20.169Z"
+    },
+    "https://mcp-ai-assistant-azk8s.connectedpdf.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:21.163Z"
+    },
+    "https://mcp-api.unified.to/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 400",
+      "checkedAt": "2026-08-28T04:12:21.082Z"
+    },
+    "https://mcp-app-api.p-c3-e.abema-tv.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:20.978Z"
+    },
+    "https://mcp-app.kickresume.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:20.972Z"
+    },
+    "https://mcp-app.mcp.prod-1.blabla.tech/mcp?token=NX8dG7rhyozGCcg5i3BrmJSigeqKB5pzdrR8g8Rt": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:20.942Z"
+    },
+    "https://mcp-app.turkishtechlab.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:20.931Z"
+    },
+    "https://mcp-apps-platform.naturalint.com/openai/bestmoney_car_insurance_app/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:20.920Z"
+    },
+    "https://mcp-backend.boyner.com.tr/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:20.902Z"
+    },
+    "https://mcp-blue.littlecaesars.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:20.902Z"
+    },
+    "https://mcp-catalog.cafe24.com/api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:20.885Z"
+    },
+    "https://mcp-demo.airwallex.com/developer": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:20.864Z"
+    },
+    "https://mcp-detprm6tzq-uc.a.run.app": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:20.850Z"
+    },
+    "https://mcp-gateway-external-pilot.spotify.net/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:20.822Z"
+    },
+    "https://mcp-gpt.dist.flix.tech/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:20.727Z"
+    },
+    "https://mcp-gpt.recorrido.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:20.711Z"
+    },
+    "https://mcp-hnh4eph34q-uc.a.run.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:20.691Z"
+    },
+    "https://mcp-london-transport-demo.onrender.com/mcp": {
+      "status": "unknown",
+      "detail": "The operation timed out.",
+      "checkedAt": "2026-08-28T04:12:20.691Z"
+    },
+    "https://mcp-main-406f710.accuweather.zuplo.work/v0/mcp/chatgpt?key=zpka_REDACTED": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:20.628Z"
+    },
+    "https://mcp-new.mychoice.ca/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:20.626Z"
+    },
+    "https://mcp-openai.carrefour.fr/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:20.605Z"
+    },
+    "https://mcp-openai.yelp.com/mcp/": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:20.598Z"
+    },
+    "https://mcp-prod.bitdj.com/mcp_server/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:20.589Z"
+    },
+    "https://mcp-prod.breethe.com": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:20.575Z"
+    },
+    "https://mcp-pub.aiera.com/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:20.503Z"
+    },
+    "https://mcp-regal.boxoffice.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:20.492Z"
+    },
+    "https://mcp-server.district.in/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:20.483Z"
+    },
+    "https://mcp-server.egnyte.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:20.420Z"
+    },
+    "https://mcp-server.internshala.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:20.403Z"
+    },
+    "https://mcp-server.prd.athome.lu/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:20.389Z"
+    },
+    "https://mcp-server.prd.luxauto.lu/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:20.350Z"
+    },
+    "https://mcp-server.signnow.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:20.322Z"
+    },
+    "https://mcp-server.zomato.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:20.302Z"
+    },
+    "https://mcp-services.wanderu.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:20.288Z"
+    },
+    "https://mcp-smart-search.skillshare.com/dense-vector-hybrid/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 530",
+      "checkedAt": "2026-08-28T04:12:20.250Z"
+    },
+    "https://mcp-test.glama.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:20.231Z"
+    },
+    "https://mcp-ui.daft.ie/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:20.214Z"
+    },
+    "https://mcp-ui.donedeal.ie/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:20.207Z"
+    },
+    "https://mcp-ultrasearch.etraveligroup.com/mcp": {
+      "status": "unknown",
+      "detail": "The operation timed out.",
+      "checkedAt": "2026-08-28T04:12:20.194Z"
+    },
+    "https://mcp-universal.conductor.com/mcp/v2": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:20.175Z"
+    },
+    "https://mcp-v1-1.labs.production.gteng.co/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:20.169Z"
+    },
+    "https://mcp.{region}.signoz.cloud/mcp": {
+      "status": "dead",
+      "detail": "Unable to connect. Is the computer able to access the url?",
+      "checkedAt": "2026-08-28T04:12:11.212Z"
+    },
+    "https://mcp.12andus.com/mcp/?v=10": {
+      "status": "unknown",
+      "detail": "HTTP 200, no initialize result",
+      "checkedAt": "2026-08-28T04:12:20.162Z"
+    },
+    "https://mcp.12go.asia/chatgpt-sse?k=ey0hbGcpOpJFUzI1NpIsImtpZ1I6InM3V09lNzAzUXA2Z2VESkU0bWl6SHlTVU5ySm1MTElrbnRWS0ZNT2lwzjgp01": {
+      "status": "unknown",
+      "detail": "HTTP 405",
+      "checkedAt": "2026-08-28T04:12:20.140Z"
+    },
+    "https://mcp.accessowl.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:20.139Z"
+    },
+    "https://mcp.adalo.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:20.125Z"
+    },
+    "https://mcp.adobeaemcloud.com/adobe/mcp/aem": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:20.116Z"
+    },
+    "https://mcp.agilitycms.com/api/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:20.081Z"
+    },
+    "https://mcp.ai.pulumi.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:20.080Z"
+    },
+    "https://mcp.airbyte.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:20.048Z"
+    },
+    "https://mcp.airtable.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:20.027Z"
+    },
+    "https://mcp.alpaca.markets/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:20.000Z"
+    },
+    "https://mcp.alpic.ai": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.993Z"
+    },
+    "https://mcp.alpy.com/": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:19.987Z"
+    },
+    "https://mcp.amplifyr.me/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.985Z"
+    },
+    "https://mcp.amplitude.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.982Z"
+    },
+    "https://mcp.api-and-you.com/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 502",
+      "checkedAt": "2026-08-28T04:12:19.957Z"
+    },
+    "https://mcp.api.clutch.ca/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.946Z"
+    },
+    "https://mcp.api.getagent.co.uk/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:19.945Z"
+    },
+    "https://mcp.api.getguru.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.884Z"
+    },
+    "https://mcp.api.gusto.com/anthropic": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.877Z"
+    },
+    "https://mcp.api.harmonic.ai": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.874Z"
+    },
+    "https://mcp.api.smarty.com/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.870Z"
+    },
+    "https://mcp.apify.com/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.843Z"
+    },
+    "https://mcp.apollo.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.841Z"
+    },
+    "https://mcp.apollographql.com": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:19.829Z"
+    },
+    "https://mcp.app.docketai.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.829Z"
+    },
+    "https://mcp.app.palomaparties.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:19.791Z"
+    },
+    "https://mcp.articlegalaxy.com/ag/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.777Z"
+    },
+    "https://mcp.asana.com/v2/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.736Z"
+    },
+    "https://mcp.assetvision.com.au/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.722Z"
+    },
+    "https://mcp.atlassian.com/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.721Z"
+    },
+    "https://mcp.atlassian.com/v1/mcp/authv2": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.720Z"
+    },
+    "https://mcp.atlys.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:19.675Z"
+    },
+    "https://mcp.attio.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.581Z"
+    },
+    "https://mcp.audible.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:19.538Z"
+    },
+    "https://mcp.auraintelligence.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.528Z"
+    },
+    "https://mcp.authzed.com": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:19.513Z"
+    },
+    "https://mcp.autoverzekering.nl/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:19.503Z"
+    },
+    "https://mcp.avo.app/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.501Z"
+    },
+    "https://mcp.aweber.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.493Z"
+    },
+    "https://mcp.axiom.co/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.469Z"
+    },
+    "https://mcp.backstage.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:19.469Z"
+    },
+    "https://mcp.benevity.org/general/v1/nonprofit": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:19.458Z"
+    },
+    "https://mcp.bestlawyers.com": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:19.454Z"
+    },
+    "https://mcp.bigdata.com/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.444Z"
+    },
+    "https://mcp.biggeo.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.416Z"
+    },
+    "https://mcp.blockscout.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:19.368Z"
+    },
+    "https://mcp.box.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.297Z"
+    },
+    "https://mcp.brand24.com/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.291Z"
+    },
+    "https://mcp.brevo.com/v1/brevo/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.290Z"
+    },
+    "https://mcp.brightdata.com/sse?token=YOUR_API_TOKEN": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:19.260Z"
+    },
+    "https://mcp.browserbase.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:19.253Z"
+    },
+    "https://mcp.builder.io/mcp/publish": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.240Z"
+    },
+    "https://mcp.buser.com.br/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.230Z"
+    },
+    "https://mcp.cal.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.225Z"
+    },
+    "https://mcp.calendly.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.202Z"
+    },
+    "https://mcp.candid.org/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.187Z"
+    },
+    "https://mcp.canva.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.185Z"
+    },
+    "https://mcp.carbonarc.ai": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.183Z"
+    },
+    "https://mcp.carbonarc.co": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.169Z"
+    },
+    "https://mcp.cars24.com": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:19.127Z"
+    },
+    "https://mcp.carsguide.com.au/mcp/wHXYY2hgbt3AiUCpc4LfwxBqflDvZ4JOkyTnJDNfXbWwXDPAtlInfIpH4OO7FgR1e": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:19.127Z"
+    },
+    "https://mcp.cartesia.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.115Z"
+    },
+    "https://mcp.carwale.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:19.115Z"
+    },
+    "https://mcp.cashbackhive.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:19.115Z"
+    },
+    "https://mcp.cbinsights.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.089Z"
+    },
+    "https://mcp.channel99.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.089Z"
+    },
+    "https://mcp.chartmogul.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.055Z"
+    },
+    "https://mcp.checkr.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:19.023Z"
+    },
+    "https://mcp.cinemo.fun/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:19.004Z"
+    },
+    "https://mcp.clerk.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:19.003Z"
+    },
+    "https://mcp.clickup.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.956Z"
+    },
+    "https://mcp.close.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.956Z"
+    },
+    "https://mcp.cloud.cdata.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.945Z"
+    },
+    "https://mcp.cloud.coveo.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.928Z"
+    },
+    "https://mcp.columnapi.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:18.928Z"
+    },
+    "https://mcp.cometchat.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:18.924Z"
+    },
+    "https://mcp.commonroom.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.895Z"
+    },
+    "https://mcp.confident-ai.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.890Z"
+    },
+    "https://mcp.confirmtkt.com/trains-ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:18.843Z"
+    },
+    "https://mcp.consensus.app/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.834Z"
+    },
+    "https://mcp.contentful.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.822Z"
+    },
+    "https://mcp.context7.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:18.822Z"
+    },
+    "https://mcp.cosmicjs.com/v1/buckets/{your-bucket-slug}": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.787Z"
+    },
+    "https://mcp.cottages.com": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:18.715Z"
+    },
+    "https://mcp.coupler.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.703Z"
+    },
+    "https://mcp.courier.com": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:18.700Z"
+    },
+    "https://mcp.craft.do/my/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.671Z"
+    },
+    "https://mcp.crossbeam.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.671Z"
+    },
+    "https://mcp.cruisebound.com/openai/sse": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:18.653Z"
+    },
+    "https://mcp.crypto.com/market-data/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:18.628Z"
+    },
+    "https://mcp.cubesoftware.com/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.576Z"
+    },
+    "https://mcp.daloopa.com/server/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.483Z"
+    },
+    "https://mcp.dams.aws.accor.com/v1/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:18.483Z"
+    },
+    "https://mcp.dataforseo.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.466Z"
+    },
+    "https://mcp.datesnrates.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:18.423Z"
+    },
+    "https://mcp.datocms.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.396Z"
+    },
+    "https://mcp.descope.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.359Z"
+    },
+    "https://mcp.devcycle.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.344Z"
+    },
+    "https://mcp.dice.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:18.333Z"
+    },
+    "https://mcp.docusign.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:18.319Z"
+    },
+    "https://mcp.domotz.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.293Z"
+    },
+    "https://mcp.draftkings.com/sports/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:18.282Z"
+    },
+    "https://mcp.dremio.cloud/mcp/{project_id}": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.267Z"
+    },
+    "https://mcp.dropbox.com/chatgpt_app_mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.238Z"
+    },
+    "https://mcp.dropbox.com/dash_chatgpt_app": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.227Z"
+    },
+    "https://mcp.dub.sh/mcp/dub-partners": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.200Z"
+    },
+    "https://mcp.employers.com/direct/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:18.189Z"
+    },
+    "https://mcp.envoy.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.164Z"
+    },
+    "https://mcp.eodhd.com/v1/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:18.144Z"
+    },
+    "https://mcp.esky.com/mcpgpttc": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:18.122Z"
+    },
+    "https://mcp.eu.algolia.com/1/M_CIMvH38zVydbZOtDAzTjI3szBOMUq0tDA0NTJOMjO3TEtLtUwxNDUxNrfOrdRNyU8u1s1NLMpOyS_PszY0NzMyNDA1sDQFAA/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:18.116Z"
+    },
+    "https://mcp.exa.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:18.116Z"
+    },
+    "https://mcp.excalidraw.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:18.052Z"
+    },
+    "https://mcp.facebook.com/devtools": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.045Z"
+    },
+    "https://mcp.faces.app/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.042Z"
+    },
+    "https://mcp.factset.com/content/v1": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.037Z"
+    },
+    "https://mcp.fal.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:18.016Z"
+    },
+    "https://mcp.ferryhopper.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:17.980Z"
+    },
+    "https://mcp.figma.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.971Z"
+    },
+    "https://mcp.flagsmith.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.967Z"
+    },
+    "https://mcp.frankfurter.dev/": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:17.955Z"
+    },
+    "https://mcp.freshworks.dev/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.921Z"
+    },
+    "https://mcp.frontapp.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.897Z"
+    },
+    "https://mcp.fyxer.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.871Z"
+    },
+    "https://mcp.g2.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.871Z"
+    },
+    "https://mcp.gamma.app/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.869Z"
+    },
+    "https://mcp.getdex.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:17.869Z"
+    },
+    "https://mcp.global.datasite.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.807Z"
+    },
+    "https://mcp.gocardless.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.807Z"
+    },
+    "https://mcp.gojinko.com": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:17.770Z"
+    },
+    "https://mcp.gorgias.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.757Z"
+    },
+    "https://mcp.granola.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.713Z"
+    },
+    "https://mcp.grep.app": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:17.704Z"
+    },
+    "https://mcp.groundcover.com/api/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.695Z"
+    },
+    "https://mcp.gumloop.com/gumloop/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.685Z"
+    },
+    "https://mcp.habitify.me/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.668Z"
+    },
+    "https://mcp.heepsy.com/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:17.650Z"
+    },
+    "https://mcp.hemlak.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:17.606Z"
+    },
+    "https://mcp.heygen.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.557Z"
+    },
+    "https://mcp.hipages.com.au/v1": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:17.521Z"
+    },
+    "https://mcp.honeycomb.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.519Z"
+    },
+    "https://mcp.hubspot.com/anthropic": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.494Z"
+    },
+    "https://mcp.imedidata.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.480Z"
+    },
+    "https://mcp.incident.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.475Z"
+    },
+    "https://mcp.indeed.com/claude/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.467Z"
+    },
+    "https://mcp.infra.wesur.fr/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:17.440Z"
+    },
+    "https://mcp.inkeep.com/payabli/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:17.396Z"
+    },
+    "https://mcp.inline.chat/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.385Z"
+    },
+    "https://mcp.inpost-group.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:17.338Z"
+    },
+    "https://mcp.insurify.com/compare-quotes": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:17.324Z"
+    },
+    "https://mcp.intercom.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.302Z"
+    },
+    "https://mcp.ipinfo.io/": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:17.302Z"
+    },
+    "https://mcp.isango.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:17.276Z"
+    },
+    "https://mcp.jam.dev/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.269Z"
+    },
+    "https://mcp.jaz.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.259Z"
+    },
+    "https://mcp.jca.experteer.com/mcp/4688951b6d7da4fa5a66399f31944d4ba15c5078ef88d82f56bf7515d3711f7d": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:17.259Z"
+    },
+    "https://mcp.jina.ai/v1": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:17.252Z"
+    },
+    "https://mcp.jobright.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:17.239Z"
+    },
+    "https://mcp.jobtome.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:17.176Z"
+    },
+    "https://mcp.jotform.com/mcp-app": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.176Z"
+    },
+    "https://mcp.k.owkin.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.136Z"
+    },
+    "https://mcp.kiwi.com": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:17.055Z"
+    },
+    "https://mcp.klaviyo.com/mcp?include-mcp-app=true": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:17.004Z"
+    },
+    "https://mcp.klook.com/v2/aiappsbff/public/openai/apps-mcp-server": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:17.001Z"
+    },
+    "https://mcp.kosik.cz/mcp-openai/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.961Z"
+    },
+    "https://mcp.krisp.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.957Z"
+    },
+    "https://mcp.kynapp.ca/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:16.957Z"
+    },
+    "https://mcp.labs.storyblok.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:16.742Z"
+    },
+    "https://mcp.lambus.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.722Z"
+    },
+    "https://mcp.lapyme.com.ar/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.719Z"
+    },
+    "https://mcp.lastminute.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:16.704Z"
+    },
+    "https://mcp.ldccai.com/lottechemical": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:16.704Z"
+    },
+    "https://mcp.ldccai.com/lottefinechem": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:16.704Z"
+    },
+    "https://mcp.ldccai.com/lottehimart": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:16.635Z"
+    },
+    "https://mcp.ldccai.com/lottehomeshopping": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:16.635Z"
+    },
+    "https://mcp.ldccai.com/lotteon": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:16.603Z"
+    },
+    "https://mcp.lesfurets.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:16.587Z"
+    },
+    "https://mcp.lfmall.co.kr/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:16.587Z"
+    },
+    "https://mcp.liblab.io/liblab": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:16.529Z"
+    },
+    "https://mcp.lifttrackapp.com/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.527Z"
+    },
+    "https://mcp.lilt.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.499Z"
+    },
+    "https://mcp.linear.app/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.481Z"
+    },
+    "https://mcp.linklyhq.com": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:16.454Z"
+    },
+    "https://mcp.listalpha.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.413Z"
+    },
+    "https://mcp.localfalcon.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.413Z"
+    },
+    "https://mcp.logrocket.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.387Z"
+    },
+    "https://mcp.logto.io": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.370Z"
+    },
+    "https://mcp.lona.agency/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.333Z"
+    },
+    "https://mcp.loomalabs.ai/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:16.326Z"
+    },
+    "https://mcp.lowes.com/lowes-oai-mcp/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:16.309Z"
+    },
+    "https://mcp.lucid.app/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.308Z"
+    },
+    "https://mcp.luminpdf.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.305Z"
+    },
+    "https://mcp.lusha.com/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.280Z"
+    },
+    "https://mcp.lytical.ai": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.279Z"
+    },
+    "https://mcp.magicpatterns.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.233Z"
+    },
+    "https://mcp.mail.superhuman.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.223Z"
+    },
+    "https://mcp.mailerlite.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.176Z"
+    },
+    "https://mcp.mailersend.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.136Z"
+    },
+    "https://mcp.make.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.104Z"
+    },
+    "https://mcp.makeaviz.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:16.059Z"
+    },
+    "https://mcp.manus.im/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:16.000Z"
+    },
+    "https://mcp.marcopolo.dev": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.987Z"
+    },
+    "https://mcp.massive.com/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.983Z"
+    },
+    "https://mcp.meetgeek.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.958Z"
+    },
+    "https://mcp.melon.com/mcp/": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:15.958Z"
+    },
+    "https://mcp.mem.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.958Z"
+    },
+    "https://mcp.mem0.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.872Z"
+    },
+    "https://mcp.mercury.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.845Z"
+    },
+    "https://mcp.mervia.ai/mcp/s/ovios-furn-b85c0919": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:15.837Z"
+    },
+    "https://mcp.metaview.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.756Z"
+    },
+    "https://mcp.meterplan.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:15.734Z"
+    },
+    "https://mcp.middesk.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.713Z"
+    },
+    "https://mcp.midify.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:15.696Z"
+    },
+    "https://mcp.migrosone.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.696Z"
+    },
+    "https://mcp.minty.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:15.696Z"
+    },
+    "https://mcp.miro.com/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.690Z"
+    },
+    "https://mcp.mixmax.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.632Z"
+    },
+    "https://mcp.mixpanel.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.632Z"
+    },
+    "https://mcp.mollie.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.541Z"
+    },
+    "https://mcp.monday.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.498Z"
+    },
+    "https://mcp.morningstar.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.491Z"
+    },
+    "https://mcp.mospi.gov.in/": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:15.465Z"
+    },
+    "https://mcp.motra.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.398Z"
+    },
+    "https://mcp.msci.com/mcp/v1.0/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.385Z"
+    },
+    "https://mcp.music.apple.com/v1/longandcomplexstring294/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:15.383Z"
+    },
+    "https://mcp.mux.com": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:15.373Z"
+    },
+    "https://mcp.mycolive.com/sse": {
+      "status": "unknown",
+      "detail": "HTTP 405",
+      "checkedAt": "2026-08-28T04:12:15.367Z"
+    },
+    "https://mcp.myfitnesspal.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:15.360Z"
+    },
+    "https://mcp.myregistry.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:15.289Z"
+    },
+    "https://mcp.natural.co": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.283Z"
+    },
+    "https://mcp.neon.tech/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.274Z"
+    },
+    "https://mcp.neptuneflood.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:15.274Z"
+    },
+    "https://mcp.nesha.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:15.233Z"
+    },
+    "https://mcp.networksolutions.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:15.185Z"
+    },
+    "https://mcp.newrelic.com/mcp/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.179Z"
+    },
+    "https://mcp.newsifytrends.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:15.179Z"
+    },
+    "https://mcp.noodleseed.com/c3EMls6YD9cgcDqwj36M/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:15.167Z"
+    },
+    "https://mcp.noodleseed.com/Dd0U0LLqpK83pocK3vq6/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:15.175Z"
+    },
+    "https://mcp.noodleseed.com/p49oDMkJ8iailt4AnMB9/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:15.162Z"
+    },
+    "https://mcp.notion.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.086Z"
+    },
+    "https://mcp.novu.co/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.027Z"
+    },
+    "https://mcp.nuwapen.com/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.004Z"
+    },
+    "https://mcp.nyquistai.com/agent/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:15.000Z"
+    },
+    "https://mcp.omnisend.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.990Z"
+    },
+    "https://mcp.onepeloton.com": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:14.963Z"
+    },
+    "https://mcp.onkernel.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.936Z"
+    },
+    "https://mcp.onthebeach.co.uk/chatgpt/v2": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:14.934Z"
+    },
+    "https://mcp.openrouter.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.917Z"
+    },
+    "https://mcp.otter.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.835Z"
+    },
+    "https://mcp.ov.domotz.app/mcp": {
+      "status": "dead",
+      "detail": "Unable to connect. Is the computer able to access the url?",
+      "checkedAt": "2026-08-28T04:12:14.835Z"
+    },
+    "https://mcp.overstappen.nl/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:14.819Z"
+    },
+    "https://mcp.paardplaats.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:14.819Z"
+    },
+    "https://mcp.pagerduty.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.775Z"
+    },
+    "https://mcp.pandadoc.com/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.758Z"
+    },
+    "https://mcp.pane.money": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.742Z"
+    },
+    "https://mcp.parqet.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.728Z"
+    },
+    "https://mcp.particl.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.705Z"
+    },
+    "https://mcp.paypal.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.681Z"
+    },
+    "https://mcp.pga.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:14.587Z"
+    },
+    "https://mcp.phantombuster.com": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:14.587Z"
+    },
+    "https://mcp.plain.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.575Z"
+    },
+    "https://mcp.plane.so": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:14.546Z"
+    },
+    "https://mcp.platform.bird.com": {
+      "status": "dead",
+      "detail": "Unable to connect. Is the computer able to access the url?",
+      "checkedAt": "2026-08-28T04:12:14.537Z"
+    },
+    "https://mcp.platform.opentargets.org/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:14.508Z"
+    },
+    "https://mcp.polar.sh/mcp/polar-mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.508Z"
+    },
+    "https://mcp.port.io": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:14.508Z"
+    },
+    "https://mcp.portkey.ai/{server-slug}/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.508Z"
+    },
+    "https://mcp.posthog.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.455Z"
+    },
+    "https://mcp.postman.co/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:14.416Z"
+    },
+    "https://mcp.postman.com/minimal": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.375Z"
+    },
+    "https://mcp.priceline.com/penny-mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:14.370Z"
+    },
+    "https://mcp.prisma.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.369Z"
+    },
+    "https://mcp.prismic.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.368Z"
+    },
+    "https://mcp.process.st": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.277Z"
+    },
+    "https://mcp.productboard.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.270Z"
+    },
+    "https://mcp.pscale.dev/mcp/planetscale": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.238Z"
+    },
+    "https://mcp.pubnub.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.226Z"
+    },
+    "https://mcp.purchase.production.wepromise.tech/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:14.202Z"
+    },
+    "https://mcp.qovery.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.158Z"
+    },
+    "https://mcp.quartr.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.145Z"
+    },
+    "https://mcp.quicknode.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.096Z"
+    },
+    "https://mcp.quo.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:14.020Z"
+    },
+    "https://mcp.rakhys.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:13.939Z"
+    },
+    "https://mcp.razorpay.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.905Z"
+    },
+    "https://mcp.realestateapi.com/sse": {
+      "status": "unknown",
+      "detail": "HTTP 405",
+      "checkedAt": "2026-08-28T04:12:13.890Z"
+    },
+    "https://mcp.reclaim.ai/chatgpt": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.865Z"
+    },
+    "https://mcp.recommerce.com/": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:13.865Z"
+    },
+    "https://mcp.reducto.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.835Z"
+    },
+    "https://mcp.releases.sh/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:13.834Z"
+    },
+    "https://mcp.remote.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.780Z"
+    },
+    "https://mcp.render.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.773Z"
+    },
+    "https://mcp.replicate.com/sse": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.745Z"
+    },
+    "https://mcp.resume.io/": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:13.727Z"
+    },
+    "https://mcp.rootly.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.727Z"
+    },
+    "https://mcp.saleor.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:13.727Z"
+    },
+    "https://mcp.saleseq.ai": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.703Z"
+    },
+    "https://mcp.samrum.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.667Z"
+    },
+    "https://mcp.sanity.io": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.634Z"
+    },
+    "https://mcp.savecraft.gg": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.627Z"
+    },
+    "https://mcp.scrapfly.io": {
+      "status": "unknown",
+      "detail": "HTTP 405",
+      "checkedAt": "2026-08-28T04:12:13.618Z"
+    },
+    "https://mcp.scrapingbee.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:13.582Z"
+    },
+    "https://mcp.securelend.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:13.580Z"
+    },
+    "https://mcp.semaphoreci.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.580Z"
+    },
+    "https://mcp.semrush.com/openai/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.580Z"
+    },
+    "https://mcp.sentry.dev/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.522Z"
+    },
+    "https://mcp.serpapi.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.477Z"
+    },
+    "https://mcp.serpstat.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.472Z"
+    },
+    "https://mcp.services.biorender.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.418Z"
+    },
+    "https://mcp.shippo.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.411Z"
+    },
+    "https://mcp.shopee.com/openai/v1": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:13.389Z"
+    },
+    "https://mcp.shortcut.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.372Z"
+    },
+    "https://mcp.similarweb.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.331Z"
+    },
+    "https://mcp.simply-family-budget.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.310Z"
+    },
+    "https://mcp.sky.blackbaud.com/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.282Z"
+    },
+    "https://mcp.slack.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.281Z"
+    },
+    "https://mcp.slidesgpt.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:13.240Z"
+    },
+    "https://mcp.smartsheet.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.198Z"
+    },
+    "https://mcp.spinify.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.178Z"
+    },
+    "https://mcp.splice.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.175Z"
+    },
+    "https://mcp.squareup.com/sse": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.170Z"
+    },
+    "https://mcp.staircase.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.167Z"
+    },
+    "https://mcp.steadily.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:13.150Z"
+    },
+    "https://mcp.steer.coach/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.104Z"
+    },
+    "https://mcp.sticklight.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.078Z"
+    },
+    "https://mcp.storage.dev/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.071Z"
+    },
+    "https://mcp.stripe.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.057Z"
+    },
+    "https://mcp.strivemaths.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:13.057Z"
+    },
+    "https://mcp.stytch.dev/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.038Z"
+    },
+    "https://mcp.subdivide.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:13.020Z"
+    },
+    "https://mcp.substack.com/api/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:13.001Z"
+    },
+    "https://mcp.supabase.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:12.975Z"
+    },
+    "https://mcp.supermetrics.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:12.943Z"
+    },
+    "https://mcp.superserve.ai": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:12.891Z"
+    },
+    "https://mcp.surveymonkey.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:12.862Z"
+    },
+    "https://mcp.sybill.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:12.836Z"
+    },
+    "https://mcp.symbol.chat/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:12.834Z"
+    },
+    "https://mcp.synapse.org/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:12.795Z"
+    },
+    "https://mcp.taskrabbit.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:12.777Z"
+    },
+    "https://mcp.tavily.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:12.733Z"
+    },
+    "https://mcp.thumbtack.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:12.671Z"
+    },
+    "https://mcp.tickettailor.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:12.654Z"
+    },
+    "https://mcp.tigerdata.com/docs": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:12.618Z"
+    },
+    "https://mcp.to3d.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:12.556Z"
+    },
+    "https://mcp.tokenterminal.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:12.556Z"
+    },
+    "https://mcp.tonita.co/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:12.556Z"
+    },
+    "https://mcp.tradein.recommerce.com": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:12.470Z"
+    },
+    "https://mcp.traktorpool.com/chatgpt-892332849/mcp/": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:12.455Z"
+    },
+    "https://mcp.trashpandaapp.com/v1/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:12.455Z"
+    },
+    "https://mcp.travelenie.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:12.424Z"
+    },
+    "https://mcp.trivago.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:12.379Z"
+    },
+    "https://mcp.trufflejournal.com/api/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:12.352Z"
+    },
+    "https://mcp.trychroma.com/package-search/v1": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:12.319Z"
+    },
+    "https://mcp.trymalcolm.com/mcp-ab2a870c-468a-418a-b695-09a30559a22a": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:12.307Z"
+    },
+    "https://mcp.turo.com/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:12.303Z"
+    },
+    "https://mcp.turso.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:12.284Z"
+    },
+    "https://mcp.uber.com/claude/rides-3p/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:12.214Z"
+    },
+    "https://mcp.ubereats.com/eats-claude/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:12.155Z"
+    },
+    "https://mcp.upsun.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:12.155Z"
+    },
+    "https://mcp.uptimerobot.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:12.143Z"
+    },
+    "https://mcp.ur.com/public/eyJvcmdhbml6YXRpb24iOiJvcmdfSlhWRjhIeHFERERmcGszSCIsImNv2UxNWRhZTdiZGQ1NGIxMTk1NTY3MmQ2MDgyMjkyMDQtYXV0b2dlbmVyYXRlZCJ9": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:12.112Z"
+    },
+    "https://mcp.usenotra.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:12.111Z"
+    },
+    "https://mcp.usepylon.com/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:12.055Z"
+    },
+    "https://mcp.vakantiediscounter.nl": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:12.052Z"
+    },
+    "https://mcp.vantage.sh/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:12.029Z"
+    },
+    "https://mcp.vectoryx-api.cloud": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:12.015Z"
+    },
+    "https://mcp.vendr.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:11.940Z"
+    },
+    "https://mcp.vercel.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:11.913Z"
+    },
+    "https://mcp.vio.com/mcp?ui=true&api_key=8290b1f5cb2ba88786816b9c8469c045": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:11.902Z"
+    },
+    "https://mcp.virtuoso.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:11.856Z"
+    },
+    "https://mcp.voyage-prive.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:11.844Z"
+    },
+    "https://mcp.waldo.fyi": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:11.808Z"
+    },
+    "https://mcp.wallector.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:11.775Z"
+    },
+    "https://mcp.walletwhistle.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:11.768Z"
+    },
+    "https://mcp.wear.jp/mcp": {
+      "status": "unknown",
+      "detail": "The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()",
+      "checkedAt": "2026-08-28T04:12:11.764Z"
+    },
+    "https://mcp.webexapis.com/mcp/webex-meeting": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:11.745Z"
+    },
+    "https://mcp.webflow.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:11.718Z"
+    },
+    "https://mcp.wego.com/chatgpt-app/v1/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:11.671Z"
+    },
+    "https://mcp.whimsical.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:11.655Z"
+    },
+    "https://mcp.wikiloc.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:11.643Z"
+    },
+    "https://mcp.windsor.ai": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:11.607Z"
+    },
+    "https://mcp.withbites.com": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:11.590Z"
+    },
+    "https://mcp.withwandb.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:11.579Z"
+    },
+    "https://mcp.wix.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:11.561Z"
+    },
+    "https://mcp.workos.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:11.543Z"
+    },
+    "https://mcp.wrike.com/app/mcp/stream": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:11.479Z"
+    },
+    "https://mcp.wyndhamhotels.com/chatgpt/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:11.438Z"
+    },
+    "https://mcp.wyndhamhotels.com/claude/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:11.425Z"
+    },
+    "https://mcp.zapier.com/api/v1/connect": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:11.401Z"
+    },
+    "https://mcp.zillow.com/api/v1": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:11.401Z"
+    },
+    "https://mcp.zocks.io/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:11.365Z"
+    },
+    "https://mcp.zoho.com": {
+      "status": "unknown",
+      "detail": "HTTP 400",
+      "checkedAt": "2026-08-28T04:12:11.362Z"
+    },
+    "https://mcp.zoho.in/": {
+      "status": "unknown",
+      "detail": "HTTP 400",
+      "checkedAt": "2026-08-28T04:12:11.321Z"
+    },
+    "https://mcp.zola.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:11.319Z"
+    },
+    "https://mcp.zoom.us/mcp/zoom/streamable": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:11.319Z"
+    },
+    "https://mcp.zoominfo.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:11.278Z"
+    },
+    "https://mcp.zoopla.co.uk/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:11.251Z"
+    },
+    "https://mcp.zumba.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:11.246Z"
+    },
+    "https://mcp2.readwise.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:11.202Z"
+    },
+    "https://mcpapps.cdiscount.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:11.199Z"
+    },
+    "https://mcptotal.io/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 200, no initialize result",
+      "checkedAt": "2026-08-28T04:12:11.159Z"
+    },
+    "https://medeloop-mcp.medeloop.ai/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 503",
+      "checkedAt": "2026-08-28T04:12:11.102Z"
+    },
+    "https://meditation.widgets.widget.olutely.com/meditation/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:11.031Z"
+    },
+    "https://member-api.shipt.com/marketplace-mcp/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:11.027Z"
+    },
+    "https://mentirosa.vercel.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.984Z"
+    },
+    "https://metronome.widgets.widget.olutely.com/metronome/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.971Z"
+    },
+    "https://migma.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:10.953Z"
+    },
+    "https://mintlify.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:10.952Z"
+    },
+    "https://miracle-mcp.sadhguru.org/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.894Z"
+    },
+    "https://molaimcp.mavriq.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:10.886Z"
+    },
+    "https://mondoir.art/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:10.875Z"
+    },
+    "https://monitoring.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.869Z"
+    },
+    "https://mortgage-calculator-o7vv.onrender.com/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:10.864Z"
+    },
+    "https://mortgage-calculator.widgets.widget.olutely.com/mortgage-calculator/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.859Z"
+    },
+    "https://moviepick.app/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:10.843Z"
+    },
+    "https://my-budget-planner.onrender.com/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:10.843Z"
+    },
+    "https://my-mcp-server-flame.vercel.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.782Z"
+    },
+    "https://my.bluesuite.app/api/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:10.740Z"
+    },
+    "https://na-beer-finder.beerfinder.workers.dev/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.710Z"
+    },
+    "https://nature-sounds.widgets.widget.olutely.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.696Z"
+    },
+    "https://neartail.com/mcp/116858831459398171161": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:10.691Z"
+    },
+    "https://netlify-mcp.netlify.app/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:10.623Z"
+    },
+    "https://networkmanagement.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.600Z"
+    },
+    "https://neurnav.com": {
+      "status": "unknown",
+      "detail": "HTTP 200, no initialize result",
+      "checkedAt": "2026-08-28T04:12:10.600Z"
+    },
+    "https://nimbus-dev.aws.cloud.att.com/chatgptapps/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.600Z"
+    },
+    "https://noodleseed-chatgpt-a-5b531721.alpic.live/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:10.558Z"
+    },
+    "https://noteithub.com/api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.531Z"
+    },
+    "https://notify.allapp.net/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:10.531Z"
+    },
+    "https://novostavby-mcp-bridge.onrender.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.412Z"
+    },
+    "https://nuxt.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.409Z"
+    },
+    "https://oaimcp-production.up.railway.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.403Z"
+    },
+    "https://oakbrook-gpt-api-432296117705.europe-west2.run.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.345Z"
+    },
+    "https://okkanji.com/api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.314Z"
+    },
+    "https://oneuptime.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.300Z"
+    },
+    "https://open-ai-app.stubhub.net/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:10.291Z"
+    },
+    "https://openai-app-mcp-apps.prod.fos.tui/fos-mcp-app-openai-prod/mcp": {
+      "status": "unknown",
+      "detail": "The operation timed out.",
+      "checkedAt": "2026-08-28T04:12:10.283Z"
+    },
+    "https://openai-app-mcp.main-production-custom.production.k8s.tubi.io/mcp": {
+      "status": "dead",
+      "detail": "Unable to connect. Is the computer able to access the url?",
+      "checkedAt": "2026-08-28T04:12:10.268Z"
+    },
+    "https://openai-app.experiancs.co.uk/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:10.268Z"
+    },
+    "https://openai-app.passby.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:10.243Z"
+    },
+    "https://openai-apps.intsig.net/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.220Z"
+    },
+    "https://openai-mcp-696419881849.us-central1.run.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.193Z"
+    },
+    "https://openai-mcp-gateway.api.prod.retail.csnglobal.net/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.162Z"
+    },
+    "https://openai-mcp.youversionapi.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.135Z"
+    },
+    "https://openai.flowerdiary.xyz/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:10.064Z"
+    },
+    "https://openai.speechify.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:10.045Z"
+    },
+    "https://openaiapp.bon-coin.net/api/openaiapp/v1/mcp/http": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:10.034Z"
+    },
+    "https://openapi.doordash.com/mcp/consumer": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:10.032Z"
+    },
+    "https://openapi.natwest.com/mortgages/v1/mcp-server-mortgages/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:09.974Z"
+    },
+    "https://openings.chessvia.ai/api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:09.964Z"
+    },
+    "https://openlens.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:09.960Z"
+    },
+    "https://orgpolicy.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:09.916Z"
+    },
+    "https://ory-docs.mcp.kapa.ai": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:09.910Z"
+    },
+    "https://outliner.chatgptapps.sider.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:09.833Z"
+    },
+    "https://paddlehq.mcp.kapa.ai": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:09.796Z"
+    },
+    "https://palette-picker.widgets.widget.olutely.com/palette-picker/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:09.761Z"
+    },
+    "https://partner-mcp.fareharbor.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:09.730Z"
+    },
+    "https://partner-mcp.ticketmaster.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:09.681Z"
+    },
+    "https://partners.api.skyscanner.net/b2b-mcp/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:09.636Z"
+    },
+    "https://pass.argorand.io/sse": {
+      "status": "unknown",
+      "detail": "HTTP 405",
+      "checkedAt": "2026-08-28T04:12:09.558Z"
+    },
+    "https://pazy-mcp-vercel.vercel.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:09.541Z"
+    },
+    "https://pcm.property24.com": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:09.534Z"
+    },
+    "https://penny.apps.trychannel3.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:09.527Z"
+    },
+    "https://pension-income-calculator.widgets.widget.olutely.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:09.514Z"
+    },
+    "https://people.googleapis.com/mcp/v1": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:09.432Z"
+    },
+    "https://petprojectcofounder.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:09.416Z"
+    },
+    "https://pg.priority-guard.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:09.412Z"
+    },
+    "https://phish.in/mcp/openai": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:09.369Z"
+    },
+    "https://photoshop-mcp-service.adobe.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:09.328Z"
+    },
+    "https://piano.widgets.widget.olutely.com/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 502",
+      "checkedAt": "2026-08-28T04:12:09.321Z"
+    },
+    "https://pier-luma.vercel.app/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 405",
+      "checkedAt": "2026-08-28T04:12:09.270Z"
+    },
+    "https://pigment.app/api/mcp/public/{id}": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:09.267Z"
+    },
+    "https://pixelesq-mcp.pixelesq.workers.dev/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:09.260Z"
+    },
+    "https://platform.zen7.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:09.228Z"
+    },
+    "https://playdeveloperreporting.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:09.215Z"
+    },
+    "https://playmcp.kakao.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:09.203Z"
+    },
+    "https://poker-api.jiqiren.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:09.199Z"
+    },
+    "https://policytroubleshooter.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:09.165Z"
+    },
+    "https://portfolio-optimizer-svpa.onrender.com/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:09.144Z"
+    },
+    "https://pregnancy-snapshot.widgets.widget.olutely.com/pregnancy-snapshot/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:09.131Z"
+    },
+    "https://premium.mcp.pitchbook.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:09.120Z"
+    },
+    "https://preply.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:09.102Z"
+    },
+    "https://price-alerts.widgets.widget.olutely.com/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 502",
+      "checkedAt": "2026-08-28T04:12:09.096Z"
+    },
+    "https://primitive.dev/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:09.029Z"
+    },
+    "https://prod-chatgpt-app.prod.bandsintown.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:09.021Z"
+    },
+    "https://prod-v1.mcp.m6.fr/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:09.020Z"
+    },
+    "https://prod.bettermg.com/api/mortgage/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:09.008Z"
+    },
+    "https://prod.infoseek.ai/api/mcp/mapify": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.954Z"
+    },
+    "https://prod.mcp.dazzly.co/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:08.952Z"
+    },
+    "https://product-scanner.widgets.widget.olutely.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.947Z"
+    },
+    "https://production.ai-mcp-extensibility-prd.tamg.cloud/ogMvjY4De1G7CiHanMOAgddl/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.906Z"
+    },
+    "https://projects.motionapp.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:08.895Z"
+    },
+    "https://proofx-mcp.fly.dev/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.893Z"
+    },
+    "https://ps-copywriting.mcp.noodleseed.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.865Z"
+    },
+    "https://public-api.wordpress.com/wpcom/v2/mcp/v1": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:08.845Z"
+    },
+    "https://pubsub.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.834Z"
+    },
+    "https://pumadb.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:08.825Z"
+    },
+    "https://qrc-chatgpt-app.vercel.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.807Z"
+    },
+    "https://quiz.chatgptapps.sider.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:08.792Z"
+    },
+    "https://quote-display.widgets.widget.olutely.com/quote-display/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.771Z"
+    },
+    "https://quotecraft-ai-zeta.vercel.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.739Z"
+    },
+    "https://rabbu.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.691Z"
+    },
+    "https://ramp-mcp-remote.ramp.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:08.680Z"
+    },
+    "https://ray-arceneaux-ai-agentic.replit.app/mcp": {
+      "status": "unknown",
+      "detail": "The operation timed out.",
+      "checkedAt": "2026-08-28T04:12:08.627Z"
+    },
+    "https://recipe-reader.widgets.widget.olutely.com/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 502",
+      "checkedAt": "2026-08-28T04:12:08.627Z"
+    },
+    "https://recommender.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.581Z"
+    },
+    "https://record.widgets.widget.olutely.com/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 502",
+      "checkedAt": "2026-08-28T04:12:08.547Z"
+    },
+    "https://redis.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.546Z"
+    },
+    "https://redocly.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.522Z"
+    },
+    "https://registry.run.mcp.com.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.515Z"
+    },
+    "https://remedy-mcp-7f3c9a42-8e6b-4b1a-9c41-2d9a6f5e8c7d.listoai.co/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 405",
+      "checkedAt": "2026-08-28T04:12:08.501Z"
+    },
+    "https://reminder-app-3pz5.onrender.com/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:08.429Z"
+    },
+    "https://remote.mcp.pipedream.net/v3": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:08.428Z"
+    },
+    "https://rental-property-calculator.onrender.com/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:08.407Z"
+    },
+    "https://rentbooking-mcp.orange.sixt.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.398Z"
+    },
+    "https://rentcafe.yardimcp.com/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:08.348Z"
+    },
+    "https://renters-mcp.skywatch.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.336Z"
+    },
+    "https://replit-mcp.com/chatgpt-app/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:08.305Z"
+    },
+    "https://replit-mcp.com/server/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:08.296Z"
+    },
+    "https://retirement-calculator-ribr.onrender.com/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:08.287Z"
+    },
+    "https://rifo-home-mcp.rifo.co/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.200Z"
+    },
+    "https://rmcp.target.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:08.189Z"
+    },
+    "https://run.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.176Z"
+    },
+    "https://runready.dev/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.122Z"
+    },
+    "https://scalar.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.113Z"
+    },
+    "https://scamguard.malwarebytes.com/claude/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:08.047Z"
+    },
+    "https://scholar.chatgptapps.sider.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:08.024Z"
+    },
+    "https://scispace.com/mcp-kls34hjb": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:07.962Z"
+    },
+    "https://scrimba.com/mcp/v2": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:07.959Z"
+    },
+    "https://seaclub-mcp-8f2c4a91-3d6e-4b7a-9f21-6c8d2e5a4b3c.listoai.co/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:07.848Z"
+    },
+    "https://search-mcp.jobkorea.co.kr/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:07.844Z"
+    },
+    "https://search-mcp.production.apartmentlist.io/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:07.833Z"
+    },
+    "https://search.mcp.depositphotos.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:07.786Z"
+    },
+    "https://searchconsole.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:07.767Z"
+    },
+    "https://seekist.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:07.762Z"
+    },
+    "https://seleven-mcp-sg.airudder.com/mcp/chatgpt_oauth": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:07.738Z"
+    },
+    "https://services.avito.ma/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:07.738Z"
+    },
+    "https://services.functionhealth.com/ai-chat/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:07.738Z"
+    },
+    "https://services.leadconnectorhq.com/mcp/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:07.738Z"
+    },
+    "https://services.leadconnectorhq.com/mcp/chatgpt": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:07.738Z"
+    },
+    "https://services.listingforgeai.it/api/mcp": {
+      "status": "unknown",
+      "detail": "The operation timed out.",
+      "checkedAt": "2026-08-28T04:12:07.674Z"
+    },
+    "https://services.webjet.com.au/api/mcp/webjetota": {
+      "status": "unknown",
+      "detail": "HTTP 200, no initialize result",
+      "checkedAt": "2026-08-28T04:12:07.601Z"
+    },
+    "https://setup.shopify.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:07.543Z"
+    },
+    "https://share-gmbh.myshopify.com/api/ucp/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:07.472Z"
+    },
+    "https://share-srkm.mcp.noodleseed.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:07.472Z"
+    },
+    "https://shop.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:07.472Z"
+    },
+    "https://shoppingcontent.googleapis.com/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:07.458Z"
+    },
+    "https://shp-apps-in-chatgpt.yahooapis.jp/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 500",
+      "checkedAt": "2026-08-28T04:12:07.456Z"
+    },
+    "https://shuftipro.com/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 502",
+      "checkedAt": "2026-08-28T04:12:07.444Z"
+    },
+    "https://simcardo.com/mcp-trip/": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:07.438Z"
+    },
+    "https://singularity-chatgpt-mcp.guestservices.theknot.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:07.432Z"
+    },
+    "https://slides.chatgptapps.sider.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:07.385Z"
+    },
+    "https://slidesgpt-server-uojeu24xoq-uc.a.run.app/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 405",
+      "checkedAt": "2026-08-28T04:12:07.363Z"
+    },
+    "https://slotted.mcp.noodleseed.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:07.335Z"
+    },
+    "https://snake-game-mcp.onrender.com/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:07.317Z"
+    },
+    "https://sobobeaches-chatgpt.onrender.com/mcp": {
+      "status": "unknown",
+      "detail": "The operation timed out.",
+      "checkedAt": "2026-08-28T04:12:07.296Z"
+    },
+    "https://softonic-mcp-server-v1.sft.product-europe.sftapi.com/mcp/demo": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:07.219Z"
+    },
+    "https://soulfamily-gpt-api.purplegrass-5a3c53cc.eastus2.azurecontainerapps.io/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:07.219Z"
+    },
+    "https://soulfamily.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:07.206Z"
+    },
+    "https://sourcegraph.com/.api/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:07.180Z"
+    },
+    "https://southeast-hre.mcp.noodleseed.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:07.146Z"
+    },
+    "https://spanner.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:07.115Z"
+    },
+    "https://speech.chatgptapps.sider.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:07.115Z"
+    },
+    "https://speed-test.widgets.widget.olutely.com/speed-test/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:07.092Z"
+    },
+    "https://spelling.widgets.widget.olutely.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:07.091Z"
+    },
+    "https://spot-mcp.usgb.io/api/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:07.026Z"
+    },
+    "https://sprouts-mcp-server.kartikay-dhar.workers.dev": {
+      "status": "unknown",
+      "detail": "HTTP 200, no initialize result",
+      "checkedAt": "2026-08-28T04:12:07.006Z"
+    },
+    "https://sqladmin.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:07.004Z"
+    },
+    "https://stopwatch.widgets.widget.olutely.com/stopwatch/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.959Z"
+    },
+    "https://storage.googleapis.com": {
+      "status": "unknown",
+      "detail": "HTTP 400",
+      "checkedAt": "2026-08-28T04:12:06.946Z"
+    },
+    "https://strapi-docs.mcp.kapa.ai": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:06.930Z"
+    },
+    "https://sudoku.widgets.widget.olutely.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.928Z"
+    },
+    "https://svc.naked.insure/quote/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:06.900Z"
+    },
+    "https://swagger.mcp.smartbear.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:06.900Z"
+    },
+    "https://talkgen.awesomize.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.719Z"
+    },
+    "https://tango.makegov.com/mcp/": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:06.712Z"
+    },
+    "https://tarot.toolpipe.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.699Z"
+    },
+    "https://tax-advisors-qa-chatgpt-app.secure.freee.co.jp/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:06.690Z"
+    },
+    "https://taxheaven-chatgpt-app.vercel.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.690Z"
+    },
+    "https://text-analysis.widgets.widget.olutely.com/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 502",
+      "checkedAt": "2026-08-28T04:12:06.690Z"
+    },
+    "https://th-chatgpt.rbi.digital/api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.690Z"
+    },
+    "https://tickersage.toolpipe.ai/mcp": {
+      "status": "unknown",
+      "detail": "The operation timed out.",
+      "checkedAt": "2026-08-28T04:12:06.690Z"
+    },
+    "https://tides.widgets.widget.olutely.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.648Z"
+    },
+    "https://tillys.mcp.optiversal.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.648Z"
+    },
+    "https://timer.widgets.widget.olutely.com/timer/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.629Z"
+    },
+    "https://tldraw-mcp-app.tldraw.workers.dev/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.606Z"
+    },
+    "https://tomba.io/.well-known/mcp/server-card.json": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:06.601Z"
+    },
+    "https://tools.bed-and-breakfast.it/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.585Z"
+    },
+    "https://translate.bluente.com/api/gpt-app/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:06.572Z"
+    },
+    "https://travel-checklist-q79n.onrender.com/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:06.569Z"
+    },
+    "https://travelimpactmodel.googleapis.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.560Z"
+    },
+    "https://travelsafety-un15.onrender.com/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:06.485Z"
+    },
+    "https://travexpserver-1-5480123242.us-central1.run.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.481Z"
+    },
+    "https://tripbtoz-mcp-gateway.tripbtoz.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.420Z"
+    },
+    "https://trips-mcp-production-us.busbud-int.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:06.419Z"
+    },
+    "https://truesky.masteringthezodiac.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.410Z"
+    },
+    "https://trustrebound.com/api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.409Z"
+    },
+    "https://trykopi.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:06.401Z"
+    },
+    "https://ts-mcp.simplybusiness.com/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 500",
+      "checkedAt": "2026-08-28T04:12:06.374Z"
+    },
+    "https://tuio-mcp-demo.vercel.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.360Z"
+    },
+    "https://tuist.dev/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:06.348Z"
+    },
+    "https://tusalario.app/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.329Z"
+    },
+    "https://ubersuggest-mcp.neilpatelapi.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:06.310Z"
+    },
+    "https://ubsmcp.neilpatelapi.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.302Z"
+    },
+    "https://ui.nuxt.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.298Z"
+    },
+    "https://unpack.fulfilling-productivity.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.276Z"
+    },
+    "https://upplai-mcp-server-production.up.railway.app/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:06.268Z"
+    },
+    "https://usa.experian.com/api/mcp-insurance-app/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:06.256Z"
+    },
+    "https://use1-prod-bk-chatgpt-app.rbictg.com/api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.223Z"
+    },
+    "https://use1-prod-fhs-mcp.rbictg.com/api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.220Z"
+    },
+    "https://use1-prod-plk-chatgpt-app.rbictg.com/api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.195Z"
+    },
+    "https://usss-gpt-app.sonicapply.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.195Z"
+    },
+    "https://valpas-mcp-3b7e1c9d-5a42-4f8e-b6d1-9c2a7e4f1b8a.listoai.co/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.175Z"
+    },
+    "https://vast-mcp.blueskyapi.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:06.147Z"
+    },
+    "https://vibeprospecting.explorium.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:06.130Z"
+    },
+    "https://visualping.io/mcp/sse": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:06.129Z"
+    },
+    "https://vivin.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.129Z"
+    },
+    "https://wayground.com/_quizizzmcp/main/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:06.129Z"
+    },
+    "https://website-creation-mcp.e.jimdo.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:06.129Z"
+    },
+    "https://wedding-suppliers-mcp.bridebook.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:06.051Z"
+    },
+    "https://widget.getyourguide.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:06.051Z"
+    },
+    "https://wisdom-api.enterpret.com/server/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:06.021Z"
+    },
+    "https://wisebase.chatgptapps.sider.ai/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:05.987Z"
+    },
+    "https://word-search.widgets.widget.olutely.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.987Z"
+    },
+    "https://www.1800flowers.com/r/api/conversational/ai/v1/a/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.924Z"
+    },
+    "https://www.activepieces.com/.well-known/mcp/server-card.json": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:05.880Z"
+    },
+    "https://www.alltrails.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.873Z"
+    },
+    "https://www.applyboard.com/mcp/search/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.865Z"
+    },
+    "https://www.autoscout24.com/chatgpt/eu/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:05.846Z"
+    },
+    "https://www.autovit.ro/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.838Z"
+    },
+    "https://www.berlin-group.org/_api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.838Z"
+    },
+    "https://www.bigdatacloud.com/.well-known/mcp/server-card.json": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:05.822Z"
+    },
+    "https://www.cogedim.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.814Z"
+    },
+    "https://www.coursera.org/chatgpt-widgets/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:05.779Z"
+    },
+    "https://www.directbooker.ai/claude": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:05.766Z"
+    },
+    "https://www.edmunds.com/mcp/map/emo/": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.756Z"
+    },
+    "https://www.edreams.com/ai-travel-assistant/chatgpt/v1/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 406",
+      "checkedAt": "2026-08-28T04:12:05.756Z"
+    },
+    "https://www.expedia.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:05.756Z"
+    },
+    "https://www.faire.com/chatgpt/api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.756Z"
+    },
+    "https://www.feedclaw.io/api/chatgpt-app": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:05.756Z"
+    },
+    "https://www.finn.com/api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.756Z"
+    },
+    "https://www.fotocasa.es/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.753Z"
+    },
+    "https://www.fugle.tw/api/v2/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:05.753Z"
+    },
+    "https://www.genspark.ai/mcp/ai_slide": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.589Z"
+    },
+    "https://www.getperseuss.com/_api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.569Z"
+    },
+    "https://www.goupword.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.569Z"
+    },
+    "https://www.hot100.ai/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.529Z"
+    },
+    "https://www.hyatt.com/mcp/browse": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:05.518Z"
+    },
+    "https://www.italki.com/saiph/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.479Z"
+    },
+    "https://www.kactus.com/apis/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.463Z"
+    },
+    "https://www.kaggle.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.462Z"
+    },
+    "https://www.khanacademy.org/api/partner/_mcp-gateway/db8f4a30-0516-45da-9d34-e9bfae33225c/sse": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.426Z"
+    },
+    "https://www.legalzoom.com/mcp/claude/v1": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:05.419Z"
+    },
+    "https://www.loveholidays.com/ai/chatgpt": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:05.406Z"
+    },
+    "https://www.lumeimobiliaria.com.br/api/mcp/public": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.404Z"
+    },
+    "https://www.makemytrip.com/ai/mcp?src=cm": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.385Z"
+    },
+    "https://www.mcp.mixedbread.com/api/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:05.362Z"
+    },
+    "https://www.mobile.de/integration/consumer-chatgpt-app/mcp?c=6a3929ea-9f78-4d44-af4e-e345cf3f9920": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:05.354Z"
+    },
+    "https://www.moneysupermarket.com/labs/v2/mcp/": {
+      "status": "auth",
+      "detail": "HTTP 403",
+      "checkedAt": "2026-08-28T04:12:05.343Z"
+    },
+    "https://www.netatmo.com/.well-known/mcp/server-card.json": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:05.329Z"
+    },
+    "https://www.okx.com/api/v1/mcp/chatgpt": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.316Z"
+    },
+    "https://www.otomoto.pl/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.301Z"
+    },
+    "https://www.ovios-home.com/api/ucp/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.301Z"
+    },
+    "https://www.payone.com/.well-known/mcp/server-card.json": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:05.295Z"
+    },
+    "https://www.perplexity.ai/rest/computer/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:05.277Z"
+    },
+    "https://www.producthunt.com/mcp/xAOyN0Bd": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.275Z"
+    },
+    "https://www.pyxl.pro/api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.272Z"
+    },
+    "https://www.pyxl.pro/api/mcp/aihumanize": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.222Z"
+    },
+    "https://www.pyxl.pro/api/mcp/pythonmaster": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.220Z"
+    },
+    "https://www.realtor.com/frontdoor/mcp/": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.202Z"
+    },
+    "https://www.redbus.com/mcp": {
+      "status": "unknown",
+      "detail": "The operation timed out.",
+      "checkedAt": "2026-08-28T04:12:05.142Z"
+    },
+    "https://www.scholarxiv.com/api/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:05.142Z"
+    },
+    "https://www.seatpin.com/api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.142Z"
+    },
+    "https://www.send.co/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:05.102Z"
+    },
+    "https://www.sephora.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://www.shazam.com/mcp?auth=92807691": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://www.shutterstock.com/gciq/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://www.slevomat.cz/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://www.southeasthre.com/_api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://www.standvirtual.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://www.success.co/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://www.swyftfilings.com/openai/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://www.tiket.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://www.toolzy.io/api/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://www.tredict.com/api/mcp/v2/": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://www.triggercmd.com/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://www.veed.io/api/v1/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://www.venturu.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://www.workable.com/": {
+      "status": "unknown",
+      "detail": "HTTP 405",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://xpert-chatgpt-app.prod.ai.2u.com/mcp": {
+      "status": "live",
+      "detail": "HTTP 200, initialize ok",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://yango.com/mcp": {
+      "status": "unknown",
+      "detail": "HTTP 504",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://YOUR_DBT_HOST_URL/api/ai/v1/mcp/": {
+      "status": "dead",
+      "detail": "Unable to connect. Is the computer able to access the url?",
+      "checkedAt": "2026-08-28T04:12:32.195Z"
+    },
+    "https://YOUR-CHARGEBEE-SUBDOMAIN.mcp.chargebee.com/knowledge_base_agent": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:32.195Z"
+    },
+    "https://your-server-name.fastmcp.app/mcp": {
+      "status": "dead",
+      "detail": "HTTP 404",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    },
+    "https://yourorg.mcp.natoma.app/v2/profile/your-profile/github/mcp": {
+      "status": "auth",
+      "detail": "HTTP 401",
+      "checkedAt": "2026-08-28T04:12:05.033Z"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "cf:dev": "wrangler dev",
     "cf:deploy": "bun run build && wrangler deploy",
     "cf:deploy-only": "wrangler deploy",
-    "cf:setup-domain": "bun scripts/setup-cloudflare-domain.ts"
+    "cf:setup-domain": "bun scripts/setup-cloudflare-domain.ts",
+    "verify-mcp": "bun scripts/verify-mcp-endpoints.ts"
   },
   "dependencies": {
     "@astrojs/cloudflare": "^12",

--- a/scripts/normalize.ts
+++ b/scripts/normalize.ts
@@ -923,14 +923,34 @@ function buildIndex(all: Integration[]) {
       feeds: r.feeds,
       popularity: r.popularity,
       devtool: undefined,
+      // What a client must actually point at to connect this surface. Callers
+      // otherwise have to fetch the per-domain surface document just to learn
+      // it, and had no stable way to tell whether a surface was already
+      // connected — the domain is not that identifier (GitHub's MCP server
+      // lives on api.githubcopilot.com).
+      connectUrl:
+        r.kind === "mcp"
+          ? r.mcp?.remoteUrl
+          : r.kind === "openapi"
+            ? r.openapi?.specUrl
+            : r.kind === "graphql"
+              ? r.graphql?.endpoint
+              : undefined,
     };
   });
 }
 
 type IndexEntry = ReturnType<typeof buildIndex>[number];
 
+interface SearchIndexSurface {
+  kind: Kind;
+  slug: string;
+  url?: string;
+}
+
 interface SearchIndexEntry {
   domain: string;
+  surfaces: SearchIndexSurface[];
   description: string;
   kinds: Kind[];
   devtool: boolean;
@@ -939,18 +959,27 @@ interface SearchIndexEntry {
 }
 
 export function buildSearchIndex(index: IndexEntry[], zeroSurfaceDomains: readonly ZeroSurfaceDomain[] = []): SearchIndexEntry[] {
-  const map = new Map<string, { domain: string; description: string; kinds: Set<Kind>; devtool: boolean; popularity: number; total: number }>();
+  const map = new Map<string, { domain: string; description: string; kinds: Set<Kind>; devtool: boolean; popularity: number; total: number; surfaces: Map<Kind, SearchIndexSurface> }>();
   for (const r of index) {
     const domain = r.domain || r.slug;
     if (!domain) continue;
     if (isJunkDomain(domain)) continue;
     let group = map.get(domain);
     if (!group) {
-      group = { domain, description: "", kinds: new Set(), devtool: false, popularity: 0, total: 0 };
+      group = { domain, description: "", kinds: new Set(), devtool: false, popularity: 0, total: 0, surfaces: new Map() };
       map.set(domain, group);
     }
     group.total++;
     group.kinds.add(r.kind);
+    // First record per kind wins: index order already puts curated and
+    // higher-confidence rows first.
+    if (!group.surfaces.has(r.kind)) {
+      group.surfaces.set(r.kind, {
+        kind: r.kind,
+        slug: r.slug,
+        ...(r.connectUrl ? { url: r.connectUrl } : {}),
+      });
+    }
     group.popularity = Math.max(group.popularity, r.popularity ?? 0);
     group.devtool ||= r.devtool === true;
     if (!group.description && r.description) group.description = r.description.replace(/\s+/g, " ").slice(0, 110);
@@ -968,6 +997,7 @@ export function buildSearchIndex(index: IndexEntry[], zeroSurfaceDomains: readon
       devtool: false,
       popularity: 0,
       total: 0,
+      surfaces: new Map(),
     });
   }
 
@@ -976,6 +1006,15 @@ export function buildSearchIndex(index: IndexEntry[], zeroSurfaceDomains: readon
       domain: group.domain,
       description: group.description,
       kinds: KIND_ORDER.filter((kind) => group.kinds.has(kind)),
+      // Omitted rather than empty: a domain with no connectable surface should
+      // not carry an empty array on every row of a multi-thousand-entry index.
+      ...(group.surfaces.size > 0
+        ? {
+            surfaces: KIND_ORDER.filter((kind) => group.surfaces.has(kind)).map(
+              (kind) => group.surfaces.get(kind)!,
+            ),
+          }
+        : {}),
       devtool: group.devtool,
       popularity: group.popularity,
       total: group.total,

--- a/scripts/normalize.ts
+++ b/scripts/normalize.ts
@@ -709,6 +709,53 @@ interface ToolsCache {
   tools: ExtractedTool[];
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// MCP endpoint verdicts: output/mcp-endpoints.json from verify-mcp-endpoints.ts
+//
+// A large share of MCP surfaces came from LLM discovery, which will assert a
+// server at `https://<domain>/mcp` because that is the convention. Often it is
+// right. Sometimes it is not, and the catalog then sends people to an endpoint
+// that cannot work — executor's add form rejects it, but only after the click.
+// Publishing an endpoint nobody verified is the bug; this drops the ones the
+// network positively denied.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface EndpointVerdict {
+  status: "live" | "auth" | "dead" | "unknown";
+  detail: string;
+  checkedAt: string;
+}
+
+/** Structurally unpublishable regardless of what a probe says: an unsubstituted
+ *  `{placeholder}` copied out of docs, or a loopback address that could only
+ *  ever have meant the author's own machine. */
+export function isUnusableEndpoint(url: string): boolean {
+  if (/[{}]/.test(url)) return true;
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: URL parsing reports failure by throwing
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return host === "localhost" || host === "127.0.0.1" || host === "::1" || host.endsWith(".local");
+  } catch {
+    return true;
+  }
+}
+
+function applyEndpointVerdicts(recs: Integration[]): Integration[] {
+  const path = join(OUTPUT, "mcp-endpoints.json");
+  const verdicts: Record<string, EndpointVerdict> = existsSync(path)
+    ? (JSON.parse(readFileSync(path, "utf8")) as { endpoints: Record<string, EndpointVerdict> })
+        .endpoints
+    : {};
+  return recs.filter((r) => {
+    const url = r.mcp?.remoteUrl?.trim();
+    if (!url) return true;
+    if (isUnusableEndpoint(url)) return false;
+    // Only a positive denial removes a record. A timeout or a 5xx means the
+    // service had a bad minute, not that it does not exist.
+    return verdicts[url]?.status !== "dead";
+  });
+}
+
 function applyToolsCache(kind: Kind, recs: Integration[]): Integration[] {
   const dir = join(OUTPUT, "tools", kind);
   if (!existsSync(dir)) return recs;
@@ -1124,7 +1171,7 @@ function main() {
 
   const baseMcp = [
     ...curated.filter((r) => r.kind === "mcp"),
-    ...applyFavicons(applyToolsCache("mcp", applyOverrides("mcp", buildMcp())))
+    ...applyEndpointVerdicts(applyFavicons(applyToolsCache("mcp", applyOverrides("mcp", buildMcp()))))
       .filter(isPublic)
       .filter(notCurated),
   ];
@@ -1163,7 +1210,7 @@ function main() {
       }),
   );
   const discoveredBuild = buildDiscovered(knownRawDomains, knownDomainKinds, knownDomains);
-  const discovered = discoveredBuild.records.filter(isPublic);
+  const discovered = applyEndpointVerdicts(discoveredBuild.records.filter(isPublic));
   const mcp = [...baseMcp, ...discovered.filter((r) => r.kind === "mcp")];
   const openapi = [...baseOpenapi, ...discovered.filter((r) => r.kind === "openapi")];
   const graphql = [...baseGraphql, ...discovered.filter((r) => r.kind === "graphql")];

--- a/scripts/normalize.ts
+++ b/scripts/normalize.ts
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync } from 
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getDomain as tldGetDomain } from "tldts";
-import { aliasesOf, canonicalDomain } from "../src/lib/domain-aliases.ts";
+import { DOMAIN_ALIASES, canonicalDomain } from "../src/lib/domain-aliases.ts";
 
 // Registrable domain per the Public Suffix List, with the PSL's private section
 // enabled so platform-hosted services resolve to their own host
@@ -17,6 +17,7 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const SOURCES = join(ROOT, "sources");
 const DOMAINS = join(ROOT, "domains");
 const OVERRIDES = join(ROOT, "overrides");
+const CURATED = join(ROOT, "curated");
 const OUTPUT = join(ROOT, "output");
 
 mkdirSync(OUTPUT, { recursive: true });
@@ -249,6 +250,47 @@ function buildOpenapi(): Integration[] {
   }
   for (const s of manual) byKey.set(keyOf(s), s);
 
+  // Second pass: one record per (domain, title).
+  //
+  // apis.guru catalogues every deployment target and dated release of the same
+  // API as its own spec. GitHub ships 20 copies of "GitHub v3 REST API"
+  // (GHES 2.18 through 3.8, GHEC, github.ae, dated `api.github.com` variants)
+  // and Azure 510 of "NetworkManagementClient". The provider+service pass above
+  // cannot see it, because each of those IS a distinct service string — but to
+  // anyone choosing something to connect they are one integration, and left
+  // alone they make a domain's API count meaningless (github.com read as 21).
+  //
+  // Pick order: a hand-curated override wins; then the base provider (no
+  // `:service` suffix), which is the vendor's own current deployment; then the
+  // most recently updated.
+  const providerDomain = (s: ApiGuruSpec) => (s.provider ?? "").split(":")[0].toLowerCase();
+  const titleKey = (s: ApiGuruSpec) => {
+    const title = (s.title ?? "").trim().toLowerCase();
+    // No title is no evidence of sameness — keep those records distinct.
+    return title.length === 0 ? null : `${providerDomain(s)}::${title}`;
+  };
+  const rank = (s: ApiGuruSpec): number =>
+    (manualKeys.has(keyOf(s)) ? 2 : 0) + (s.provider.includes(":") ? 0 : 1);
+  const byTitle = new Map<string, ApiGuruSpec>();
+  for (const [key, s] of byKey) {
+    const group = titleKey(s);
+    if (group === null) continue;
+    const prev = byTitle.get(group);
+    if (!prev) {
+      byTitle.set(group, s);
+      continue;
+    }
+    const better =
+      rank(s) > rank(prev) ||
+      (rank(s) === rank(prev) && (s.updated ?? "") > (prev.updated ?? ""));
+    if (better) {
+      byKey.delete(keyOf(prev));
+      byTitle.set(group, s);
+    } else {
+      byKey.delete(key);
+    }
+  }
+
   const recs: Integration[] = [];
   for (const [key, s] of byKey) {
     const slug = slugify(key);
@@ -385,9 +427,13 @@ interface DiscoveredDomain {
 }
 
 const DISCOVERED_KIND_PRIORITY: Kind[] = ["mcp", "openapi", "graphql", "cli"];
-// Railway's hand-maintained CLI source moved to railway.com. Keep the old
-// crawler row deduped against that source so normalization does not add records.
-const DISCOVERED_ALIAS_DEDUPE = new Set(aliasesOf("railway.com"));
+// An alias means "same vendor", so a crawled record for the alias must not open
+// a second bucket beside the canonical domain's. This was hardcoded to
+// railway.com's one migration; every alias has the same problem, and the ones
+// that went unhandled are how a static-asset host like
+// avatars1.githubusercontent.com ended up in the catalog claiming GitHub's REST,
+// GraphQL and CLI surfaces as its own.
+const DISCOVERED_ALIAS_DEDUPE = new Set(Object.keys(DOMAIN_ALIASES));
 
 const discoveredKind = (type: DiscoveredSurfaceType): Kind => (type === "http" ? "openapi" : type);
 const domainKindKey = (domain: string, kind: Kind) => `${canonicalDomain(domain)}:${kind}`;
@@ -478,6 +524,98 @@ export function buildDiscoveredEntries(
   }
 
   return { records: dedupeSlugs(recs), zeroSurfaceDomains: [...zeroSurfaceDomains.values()] };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Curated: curated/*.json
+//
+// Hand-verified records, and the only place in this repo where a human has
+// actually checked what a vendor exposes. They were previously read by nothing
+// — the files existed and fed free text into the discovery prompt, while the
+// index was built entirely from crawled and third-party feeds. That is how
+// github.com came to list 21 API rows and no MCP server at all, while
+// curated/github.json had the correct four surfaces sitting on disk the whole
+// time.
+//
+// Curated records are built FIRST, so every later source dedupes against them.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface CuratedInterface {
+  format?: string;
+  name?: string;
+  endpoint?: string;
+  spec?: string;
+  docs?: string;
+  install?: string;
+}
+
+interface CuratedRecord {
+  slug?: string;
+  name?: string;
+  description?: string;
+  tagline?: string;
+  domain?: string;
+  icon?: string;
+  categories?: string[];
+  interfaces?: CuratedInterface[];
+}
+
+const CURATED_KIND: Record<string, Kind> = {
+  mcp: "mcp",
+  openapi: "openapi",
+  rest: "openapi",
+  http: "openapi",
+  graphql: "graphql",
+  cli: "cli",
+};
+
+export function buildCurated(): Integration[] {
+  if (!existsSync(CURATED)) return [];
+  const recs: Integration[] = [];
+  for (const file of readdirSync(CURATED)) {
+    if (!file.endsWith(".json")) continue;
+    const entry = readJson<CuratedRecord>(join(CURATED, file));
+    const domain = (entry.domain ?? "").trim().toLowerCase();
+    if (!domain) continue;
+    const description = (entry.description ?? entry.tagline ?? "").replace(/\s+/g, " ").trim();
+    const domainSlug = slugify(domain);
+    const seen = new Set<Kind>();
+    for (const iface of entry.interfaces ?? []) {
+      const kind = CURATED_KIND[(iface.format ?? "").toLowerCase()];
+      // One record per kind: the picker offers a surface, not every endpoint.
+      if (!kind || seen.has(kind)) continue;
+      seen.add(kind);
+      const rec: Integration = {
+        id: `curated/${domainSlug}-${kind}`,
+        slug: seen.size === 1 ? domainSlug : `${domainSlug}-${kind}`,
+        kind,
+        name: entry.name ?? domain,
+        description,
+        url: undefined,
+        icon: entry.icon ?? faviconUrl(domain) ?? undefined,
+        categories: entry.categories ?? [],
+        feeds: ["curated"],
+        raw: { curated: { domain, interface: iface } },
+      };
+      if (kind === "mcp") {
+        rec.mcp = { remoteUrl: iface.endpoint };
+      } else if (kind === "openapi") {
+        rec.openapi = {
+          provider: domain,
+          version: "curated",
+          specUrl: iface.spec,
+          docsUrl: iface.docs,
+          openapiVer: "",
+        };
+      } else if (kind === "graphql") {
+        rec.graphql = { endpoint: iface.endpoint ?? "", hasSecurity: true, docs: [] };
+      } else {
+        rec.cli = { install: iface.install ?? iface.name ?? "", domain };
+      }
+      recs.push(rec);
+    }
+  }
+  return dedupeSlugs(recs);
 }
 
 function buildDiscovered(
@@ -689,8 +827,14 @@ function rawRecordDomain(r: Integration): string {
   } else {
     url = r.graphql?.endpoint ?? r.url;
   }
-  const discoveredDomain = (r.raw.discovered as { domain?: string } | undefined)?.domain;
-  if (discoveredDomain) return discoveredDomain;
+  // A record that names its own domain is believed over one inferred from a
+  // URL. GitHub's MCP server lives on api.githubcopilot.com and Slack's on
+  // slack.dev — deriving the vendor from the endpoint host files those under
+  // the wrong product entirely.
+  const declaredDomain =
+    (r.raw.curated as { domain?: string } | undefined)?.domain ??
+    (r.raw.discovered as { domain?: string } | undefined)?.domain;
+  if (declaredDomain) return declaredDomain;
   return (url ? getDomain(url) : null) ?? (r.url ? getDomain(r.url) ?? "" : "");
 }
 
@@ -931,10 +1075,36 @@ function main() {
   // Order: build feed records → apply overrides (may add new records) → fill
   // tools from cache → swap broken icons for domain-based fallbacks → keep only
   // publicly-accessible records.
-  const baseMcp = applyFavicons(applyToolsCache("mcp", applyOverrides("mcp", buildMcp()))).filter(isPublic);
-  const baseOpenapi = applyFavicons(applyToolsCache("openapi", applyOverrides("openapi", buildOpenapi()))).filter(isPublic);
-  const baseGraphql = applyFavicons(applyToolsCache("graphql", applyOverrides("graphql", buildGraphql()))).filter(isPublic);
-  const baseCli = buildCli().filter(isPublic);
+  // Curated records come first so every other source dedupes against them.
+  const curated = buildCurated();
+  const curatedKinds = new Set(curated.map((r) => domainKindKey(recordDomain(r), r.kind)));
+  // A crawled or third-party row for a (domain, kind) a human has already
+  // verified is noise beside it, not extra coverage.
+  const notCurated = (r: Integration) =>
+    !curatedKinds.has(domainKindKey(recordDomain(r), r.kind));
+
+  const baseMcp = [
+    ...curated.filter((r) => r.kind === "mcp"),
+    ...applyFavicons(applyToolsCache("mcp", applyOverrides("mcp", buildMcp())))
+      .filter(isPublic)
+      .filter(notCurated),
+  ];
+  const baseOpenapi = [
+    ...curated.filter((r) => r.kind === "openapi"),
+    ...applyFavicons(applyToolsCache("openapi", applyOverrides("openapi", buildOpenapi())))
+      .filter(isPublic)
+      .filter(notCurated),
+  ];
+  const baseGraphql = [
+    ...curated.filter((r) => r.kind === "graphql"),
+    ...applyFavicons(applyToolsCache("graphql", applyOverrides("graphql", buildGraphql())))
+      .filter(isPublic)
+      .filter(notCurated),
+  ];
+  const baseCli = [
+    ...curated.filter((r) => r.kind === "cli"),
+    ...buildCli().filter(isPublic).filter(notCurated),
+  ];
 
   const knownRawDomains = new Set(
     [...baseMcp, ...baseOpenapi, ...baseGraphql, ...baseCli]

--- a/scripts/verify-mcp-endpoints.ts
+++ b/scripts/verify-mcp-endpoints.ts
@@ -1,0 +1,216 @@
+#!/usr/bin/env bun
+/**
+ * Probes every catalogued MCP endpoint and records whether it answers like an
+ * MCP server.
+ *
+ * WHY THIS EXISTS. A large share of MCP surfaces reached the catalog from LLM
+ * discovery, which is happy to assert that a service runs a server at
+ * `https://<domain>/mcp` because that is the common convention. 150 catalogued
+ * endpoints have exactly that shape and none carry a verification basis. They
+ * cannot be judged by inspection — probing shows the guess is right far more
+ * often than it looks: `logging.googleapis.com/mcp` and
+ * `orgpolicy.googleapis.com/mcp` return valid initialize results, while
+ * `gmail.googleapis.com/mcp` 404s. Only the wire can tell them apart.
+ *
+ * The verdicts are conservative on purpose. A dead endpoint is one the network
+ * positively denies (404/410, unknown host, refused connection). Anything
+ * ambiguous — a timeout, a 5xx, a proxy error — is `unknown` and changes
+ * nothing, because a service being down for a minute is not evidence that it
+ * does not exist. Only `dead` removes a record.
+ *
+ * Output: output/mcp-endpoints.json, tracked like the other slow network caches
+ * (output/tools, output/favicons.json). `normalize.ts` reads it; nothing here
+ * runs at build time.
+ *
+ * Usage:
+ *   bun run scripts/verify-mcp-endpoints.ts            # probe everything
+ *   bun run scripts/verify-mcp-endpoints.ts --stale 30 # only re-probe entries older than 30 days
+ */
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const OUTPUT = join(ROOT, "output");
+const CACHE = join(OUTPUT, "mcp-endpoints.json");
+
+const CONCURRENCY = 24;
+const TIMEOUT_MS = 12_000;
+
+export type EndpointStatus = "live" | "auth" | "dead" | "unknown";
+
+export interface EndpointVerdict {
+  readonly status: EndpointStatus;
+  /** Short human reason, for auditing a verdict without re-probing. */
+  readonly detail: string;
+  readonly checkedAt: string;
+}
+
+interface Cache {
+  readonly checkedAt: string;
+  readonly endpoints: Record<string, EndpointVerdict>;
+}
+
+const INITIALIZE = JSON.stringify({
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "integrations.sh-verify", version: "1" },
+  },
+});
+
+/** An MCP server answers `initialize` with a JSON-RPC result carrying a
+ *  protocol version — over plain JSON or as an SSE `data:` frame. */
+const looksLikeMcp = (body: string): boolean => {
+  const payloads = body.includes("data:")
+    ? body
+        .split("\n")
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => line.slice(5).trim())
+    : [body];
+  for (const payload of payloads) {
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: JSON.parse reports malformed input by throwing
+    try {
+      const parsed = JSON.parse(payload) as { result?: { protocolVersion?: unknown } };
+      if (parsed?.result?.protocolVersion !== undefined) return true;
+    } catch {
+      continue;
+    }
+  }
+  return false;
+};
+
+const verdictFor = async (url: string): Promise<EndpointVerdict> => {
+  const checkedAt = new Date().toISOString();
+  const response = await (async () => {
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: fetch reports transport failure by rejecting
+    try {
+      return await fetch(url, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: INITIALIZE,
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+        redirect: "follow",
+      });
+    } catch (error) {
+      return error instanceof Error ? error : new Error(String(error));
+    }
+  })();
+
+  if (response instanceof Error) {
+    const message = response.message.toLowerCase();
+    // A host that does not resolve, or refuses the connection outright, is a
+    // positive denial. A timeout is not.
+    const denied =
+      message.includes("dns") ||
+      message.includes("getaddrinfo") ||
+      message.includes("enotfound") ||
+      message.includes("unable to connect") ||
+      message.includes("econnrefused") ||
+      message.includes("certificate");
+    return {
+      status: denied ? "dead" : "unknown",
+      detail: response.message.slice(0, 140),
+      checkedAt,
+    };
+  }
+
+  // A server that demands credentials is a server.
+  if (response.status === 401 || response.status === 403) {
+    return { status: "auth", detail: `HTTP ${response.status}`, checkedAt };
+  }
+  if (response.status === 404 || response.status === 410) {
+    return { status: "dead", detail: `HTTP ${response.status}`, checkedAt };
+  }
+  if (!response.ok) {
+    return { status: "unknown", detail: `HTTP ${response.status}`, checkedAt };
+  }
+
+  const body = await (async () => {
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: body read can fail mid-stream
+    try {
+      return await response.text();
+    } catch {
+      return "";
+    }
+  })();
+  if (looksLikeMcp(body)) {
+    return { status: "live", detail: `HTTP ${response.status}, initialize ok`, checkedAt };
+  }
+  // 200 is not proof: an API gateway will happily return its own JSON for an
+  // unrouted path. Without an initialize result this is not an MCP server, but
+  // it answered, so call it unknown rather than dead.
+  return { status: "unknown", detail: `HTTP ${response.status}, no initialize result`, checkedAt };
+};
+
+const endpointsFromCatalog = (): string[] => {
+  const path = join(OUTPUT, "mcp.json");
+  if (!existsSync(path)) {
+    console.error("output/mcp.json is missing — run `bun run normalize` first.");
+    process.exit(1);
+  }
+  const records = JSON.parse(readFileSync(path, "utf8")) as {
+    mcp?: { remoteUrl?: string };
+  }[];
+  const urls = new Set<string>();
+  for (const record of records) {
+    const url = record.mcp?.remoteUrl?.trim();
+    if (url && /^https?:\/\//i.test(url)) urls.add(url);
+  }
+  return [...urls].sort();
+};
+
+const readCache = (): Cache =>
+  existsSync(CACHE)
+    ? (JSON.parse(readFileSync(CACHE, "utf8")) as Cache)
+    : { checkedAt: "", endpoints: {} };
+
+async function main(): Promise<void> {
+  const staleArg = process.argv.indexOf("--stale");
+  const staleDays = staleArg >= 0 ? Number(process.argv[staleArg + 1] ?? "0") : 0;
+  const staleBefore =
+    staleDays > 0 ? Date.now() - staleDays * 24 * 60 * 60 * 1000 : Number.POSITIVE_INFINITY;
+
+  const previous = readCache();
+  const urls = endpointsFromCatalog();
+  const todo = urls.filter((url) => {
+    const seen = previous.endpoints[url];
+    if (!seen) return true;
+    return Date.parse(seen.checkedAt) < staleBefore;
+  });
+
+  console.log(`${urls.length} catalogued endpoints, ${todo.length} to probe`);
+  const endpoints: Record<string, EndpointVerdict> = { ...previous.endpoints };
+  let done = 0;
+
+  const queue = [...todo];
+  const workers = Array.from({ length: Math.min(CONCURRENCY, queue.length) }, async () => {
+    for (let url = queue.pop(); url !== undefined; url = queue.pop()) {
+      endpoints[url] = await verdictFor(url);
+      done++;
+      if (done % 100 === 0) console.log(`  ${done}/${todo.length}`);
+    }
+  });
+  await Promise.all(workers);
+
+  mkdirSync(OUTPUT, { recursive: true });
+  const ordered = Object.fromEntries(Object.entries(endpoints).sort(([a], [b]) => a.localeCompare(b)));
+  writeFileSync(
+    CACHE,
+    JSON.stringify({ checkedAt: new Date().toISOString(), endpoints: ordered }, null, 2) + "\n",
+  );
+
+  const tally: Record<string, number> = {};
+  for (const verdict of Object.values(ordered)) {
+    tally[verdict.status] = (tally[verdict.status] ?? 0) + 1;
+  }
+  console.log("verdicts:", tally);
+}
+
+await main();

--- a/src/lib/domain-aliases.ts
+++ b/src/lib/domain-aliases.ts
@@ -45,6 +45,12 @@ export const DOMAIN_ALIASES: Record<string, string> = {
   "intercom.io": "intercom.com",
   "letsdeel.com": "deel.com",
   "logtail.com": "betterstack.com",
+  "notion.notion.site": "notion.com",
+  "notion.so": "notion.com",
+  // Vendor docs/dev domains that the crawler discovered as separate services.
+  "shopify.dev": "shopify.com",
+  "slack.dev": "slack.com",
+  "spotify.net": "spotify.com",
   "meetcampfire.com": "campfire.ai",
   "mermaidchart.com": "mermaid.ai",
   "neon.tech": "neon.com",

--- a/src/lib/domain-aliases.ts
+++ b/src/lib/domain-aliases.ts
@@ -36,6 +36,10 @@ export const DOMAIN_ALIASES: Record<string, string> = {
   "avatars3.githubusercontent.com": "github.com",
   "avatars.githubusercontent.com": "github.com",
   "gist.githubusercontent.com": "github.com",
+  // Gmail's API host is Gmail. Left unaliased it became a second Gmail in the
+  // catalog, carrying a duplicate API surface and a fabricated MCP endpoint
+  // (https://gmail.googleapis.com/mcp/ 404s).
+  "gmail.googleapis.com": "gmail.com",
   "user-images.githubusercontent.com": "github.com",
   "graphite.dev": "graphite.com",
   "heapanalytics.com": "heap.io",

--- a/src/lib/domain-aliases.ts
+++ b/src/lib/domain-aliases.ts
@@ -28,7 +28,15 @@ export const DOMAIN_ALIASES: Record<string, string> = {
   "fellow.app": "fellow.ai",
   "frontapp.com": "front.com",
   "getpinwheel.com": "pinwheelapi.com",
+  // GitHub's asset hosts. They serve avatars and attachments, not APIs — the
+  // crawler discovered them as domains and attributed GitHub's own surfaces to
+  // them, which is worse than useless in a picker.
+  "avatars1.githubusercontent.com": "github.com",
+  "avatars2.githubusercontent.com": "github.com",
+  "avatars3.githubusercontent.com": "github.com",
+  "avatars.githubusercontent.com": "github.com",
   "gist.githubusercontent.com": "github.com",
+  "user-images.githubusercontent.com": "github.com",
   "graphite.dev": "graphite.com",
   "heapanalytics.com": "heap.io",
   "helpscout.net": "helpscout.com",

--- a/src/lib/search-index.ts
+++ b/src/lib/search-index.ts
@@ -1,8 +1,19 @@
 import searchIndexJson from "../../output/search-index.json";
 import type { Kind } from "./types.ts";
 
+/** How to connect one surface of a domain. `slug` is the registry's stable
+ *  identifier for that surface — the thing a client should record so it can
+ *  later tell whether it already added this, without inferring identity from a
+ *  hostname. */
+export interface SearchIndexSurface {
+  kind: Kind;
+  slug: string;
+  url?: string;
+}
+
 export interface SearchIndexEntry {
   domain: string;
+  surfaces?: SearchIndexSurface[];
   description: string;
   kinds: Kind[];
   devtool: boolean;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,7 +3,17 @@ export type Kind = "mcp" | "openapi" | "graphql" | "cli";
 /** Display formats. Superset of Kind: curated providers can also expose CLIs. */
 export type Format = "mcp" | "openapi" | "graphql" | "cli";
 
-export type Feed = "claude" | "openai" | "apis-guru" | "graphql-apis" | "override" | "cli-seed" | "discovered";
+export type Feed =
+  | "claude"
+  | "openai"
+  | "apis-guru"
+  | "graphql-apis"
+  | "override"
+  | "cli-seed"
+  | "discovered"
+  /** Hand-verified records in `curated/`. Highest confidence: a human checked
+   *  what the vendor actually exposes. */
+  | "curated";
 
 export interface Integration {
   id: string;

--- a/worker/api.ts
+++ b/worker/api.ts
@@ -47,12 +47,32 @@ const SearchQuery = Schema.Struct({
   ),
 });
 
+const SearchSurface = Schema.Struct({
+  kind: Kind.annotate({ description: "The kind of integration surface." }),
+  slug: Schema.String.annotate({
+    description:
+      "Stable registry identifier for this surface. Record it to recognise later that you already added this integration — the domain is not that identifier, since a vendor's surfaces can live on other hosts (GitHub's MCP server is on api.githubcopilot.com).",
+  }),
+  url: Schema.optional(
+    Schema.String.annotate({
+      description:
+        "What to point at to connect this surface: the MCP endpoint, the OpenAPI spec URL, or the GraphQL endpoint. Absent when the registry has no machine-readable locator on record.",
+    }),
+  ),
+});
+
 const SearchResult = Schema.Struct({
   domain: Schema.String.annotate({ description: "Registrable domain for the catalog entry." }),
   name: Schema.String.annotate({ description: "Display name for the result. Domain-level catalog results use the domain name." }),
   description: Schema.String.annotate({ description: "Short catalog description for the service or its integration surface." }),
   kinds: Schema.Array(Kind).annotate({ description: "Integration kinds currently cataloged for this domain, in canonical display order." }),
   url: Schema.String.annotate({ description: "Canonical integrations.sh page for this domain." }),
+  surfaces: Schema.optional(
+    Schema.Array(SearchSurface).annotate({
+      description:
+        "Per-kind connect targets, so a client can connect (and recognise what it has already connected) without a second request for the domain's surface document.",
+    }),
+  ),
 });
 
 const SearchResults = Schema.Struct({
@@ -155,6 +175,13 @@ export function searchCatalog(query: typeof SearchQuery.Type, liveEntries: reado
       description: entry.description,
       kinds: entry.kinds,
       url: `https://integrations.sh/${encodeURIComponent(entry.domain)}/`,
+      ...(entry.surfaces && entry.surfaces.length > 0
+        ? {
+            surfaces: query.kind
+              ? entry.surfaces.filter((surface) => surface.kind === query.kind)
+              : entry.surfaces,
+          }
+        : {}),
     }));
   const results = appendLiveSearchResults(query, staticIndex, staticResults, liveEntries);
   return { results };


### PR DESCRIPTION
The catalog disagreed with itself. github.com listed 21 API surfaces and no MCP server, while its own detail page showed one MCP, two REST, GraphQL and a CLI. Five separate causes, each fixed here.

## Curated records now reach the index

`curated/*.json` was read by nothing. The files fed free text into the discovery prompt and were otherwise ignored, so the hand-verified picture of a vendor never reached the catalog — `curated/github.json` had the correct four surfaces on disk the whole time. Curated records are now built first and every other source dedupes against them.

Records that declare their own domain are believed over one inferred from a URL. GitHub's MCP server lives on `api.githubcopilot.com`; deriving the vendor from the endpoint host filed it under the wrong product.

## Duplicate specs collapse by (domain, title)

apis.guru catalogues every deployment target and dated release as its own spec: 20 copies of "GitHub v3 REST API" (GHES 2.18-3.8, GHEC, github.ae, dated variants), 510 of Azure's `NetworkManagementClient`. The existing provider+service pass cannot see it, because each of those is a distinct service string. Pick order: curated override, then the base provider, then most recently updated.

## Alias dedup applies to every alias

`DISCOVERED_ALIAS_DEDUPE` was hardcoded to `aliasesOf("railway.com")` — one migration, never generalised. That is how `avatars1.githubusercontent.com`, a static-asset CDN host, entered the catalog claiming GitHub's REST, GraphQL and CLI surfaces as its own.

Aliases added for GitHub's asset hosts, Gmail's API host, and vendor docs domains the crawler read as separate services (`shopify.dev`, `slack.dev`, `spotify.net`, `notion.so`, `notion.notion.site`).

## Search returns connect targets

`/api/search` now includes per-kind `surfaces` — `{ kind, slug, url }`. Consumers had to fetch the per-domain surface document just to learn where to point, and had no stable identifier to recognise an integration they had already added. The domain is not that identifier.

Omitted rather than empty on zero-surface domains. Filtered by `kind` when the query is.

## Dead MCP endpoints removed

A large share of MCP surfaces came from LLM discovery, which asserts a server at `https://<domain>/mcp` because that is the convention. 150 catalogued endpoints have exactly that shape and none carried a verification basis. They cannot be judged by inspection — `logging.googleapis.com/mcp` and `orgpolicy.googleapis.com/mcp` answer `initialize` correctly, while `gmail.googleapis.com/mcp` 404s.

`bun run verify-mcp` probes every endpoint with a real `initialize` call. Of 1,243: 572 auth (a server demanding credentials), 533 live, 77 dead, 61 unknown. Verdicts cached in `output/mcp-endpoints.json`, tracked like the other slow network caches; nothing probes at build time.

Only a positive denial removes a record. A timeout or 5xx is `unknown` and changes nothing. A 200 alone is not proof either — an API gateway returns its own JSON for an unrouted path — so an `initialize` result is required.

Removed 83 MCP records, including `http://127.0.0.1:3000/mcp` and template URLs with placeholders intact (`https://{APP_ID}.algolia.net/...`, `https://{tenant}.chronosphere.io/...`). Those also get a structural guard so they cannot return.

## Effect

- github.com: 23 rows and no MCP, to 4 rows across MCP, API, GraphQL and CLI
- avatars1.githubusercontent.com: gone
- azure.com: ~1000 rows, to 260
- one bucket per vendor for Notion, Shopify, Slack, Spotify, Gmail
- total catalog 5,758 to 5,217

Nine curated OpenAPI surfaces gained verified spec URLs; every one was fetched before committing. Google Workspace publishes Discovery documents rather than OpenAPI, and Todoist has no public spec, so both are deliberately left without one.

`output/` is regenerated at deploy, so the data changes carry no reviewable diff — the code and the probe cache do.

Tests and build pass.