### PR TITLE
Fix X API OAuth authorization URL

### DIFF
--- a/curated/x.json
+++ b/curated/x.json
@@ -1,0 +1,87 @@
+{
+  "slug": "x",
+  "name": "X",
+  "tagline": "Read and manage posts, messages, bookmarks, lists, and accounts.",
+  "description": "The X API exposes posts, users, direct messages, bookmarks, lists, Spaces, live broadcasts, and developer resources. Its OAuth 2.0 authorization-code flow supports delegated read and write access with PKCE.",
+  "domain": "x.com",
+  "icon": "https://www.google.com/s2/favicons?domain=x.com&sz=64",
+  "categories": ["communication", "social"],
+  "auth": {
+    "methods": [
+      {
+        "type": "oauth2",
+        "label": "OAuth 2.0 with PKCE",
+        "note": "Use Basic client authentication at the token endpoint for confidential clients."
+      },
+      {
+        "type": "token",
+        "label": "App-only Bearer token",
+        "note": "Supports app-only access to endpoints that do not require a user."
+      }
+    ],
+    "guide": "**OAuth 2.0 user access:** create an app in the [X Developer Console](https://developer.x.com/en/portal/dashboard), enable OAuth 2.0, and register your client's exact callback URL. Request only the scopes the agent needs. Include `offline.access` when the connection must refresh without another consent screen. Confidential clients must send the client ID and secret with HTTP Basic authentication when they call the token endpoint. Public clients send the client ID in the form body and use PKCE without a secret.\n\n```bash\nopen 'https://x.com/i/oauth2/authorize?response_type=code&client_id=$X_CLIENT_ID&redirect_uri=$CALLBACK_URL&scope=tweet.read%20users.read%20offline.access&state=$STATE&code_challenge=$CHALLENGE&code_challenge_method=S256'\n```\n\n**App-only access:** use the Bearer token from the app's Keys and Tokens page for endpoints that support application-only authentication. Direct messages, bookmarks, posting, and other user actions require user-context OAuth. The vendor OpenAPI file has an incorrect authorization URL. The catalog override replaces it with the URL documented by X.",
+    "sources": [
+      {
+        "title": "X OAuth 2.0 user access token",
+        "url": "https://docs.x.com/fundamentals/authentication/oauth-2-0/user-access-token"
+      },
+      {
+        "title": "X MCP servers and OpenAPI specification",
+        "url": "https://docs.x.com/tools/mcp"
+      }
+    ],
+    "generatedAt": "2026-08-31",
+    "verified": true
+  },
+  "interfaces": [
+    {
+      "format": "openapi",
+      "name": "X API v2",
+      "origin": "vendor",
+      "endpoint": "https://api.x.com/2",
+      "spec": "https://api.x.com/2/openapi.json",
+      "auth": "oauth",
+      "docs": "https://docs.x.com/x-api",
+      "note": "The vendor spec points OAuth authorization at api.x.com, which returns 403 in a browser. X documents x.com/i/oauth2/authorize. Confidential clients use HTTP Basic authentication at the token endpoint.",
+      "scopes": [
+        "block.read",
+        "block.write",
+        "bookmark.read",
+        "bookmark.write",
+        "broadcast.read",
+        "broadcast.write",
+        "developer.read",
+        "developer.write",
+        "dm.read",
+        "dm.write",
+        "follows.read",
+        "follows.write",
+        "like.read",
+        "like.write",
+        "list.read",
+        "list.write",
+        "media.write",
+        "mute.read",
+        "mute.write",
+        "offline.access",
+        "space.read",
+        "timeline.read",
+        "tweet.moderate.write",
+        "tweet.read",
+        "tweet.write",
+        "users.read"
+      ],
+      "specOverrides": [
+        {
+          "op": "replace",
+          "path": "/components/securitySchemes/OAuth2UserToken/flows/authorizationCode/authorizationUrl",
+          "value": "https://x.com/i/oauth2/authorize"
+        }
+      ]
+    }
+  ],
+  "links": {
+    "homepage": "https://x.com",
+    "docs": "https://docs.x.com"
+  }
+}


### PR DESCRIPTION
## Summary
- add a curated X API v2 entry
- replace the invalid OAuth authorization URL from the vendor spec
- expose the vendor OAuth scope set

## Verification
- `bun run build`
- generated catalog entry includes the JSON Patch override