### PR TITLE
Add OpenPost to integrations.sh

### DIFF
--- a/curated/openpost.json
+++ b/curated/openpost.json
@@ -1,0 +1,83 @@
+{
+  "slug": "openpost",
+  "name": "OpenPost",
+  "tagline": "Create, adapt, schedule, and track social content with agents.",
+  "description": "OpenPost is a social publishing workspace for creating, adapting, scheduling, publishing, and tracking content across connected social accounts. Its HTTP API, MCP server, and CLI share the same workspace, scope, validation, and provider-readiness rules.",
+  "domain": "openpost.social",
+  "categories": [
+    "social-media",
+    "productivity",
+    "developer-tools"
+  ],
+  "auth": {
+    "methods": [
+      {
+        "type": "oauth2",
+        "label": "MCP OAuth",
+        "note": "OAuth-aware MCP clients can request mcp:read or mcp:full and bind access to one workspace."
+      },
+      {
+        "type": "token",
+        "label": "OpenPost API token",
+        "note": "Revocable bearer tokens use interface-specific scopes and can be limited to one workspace."
+      }
+    ],
+    "guide": "**Hosted MCP:** point an OAuth-aware client at the Hosted endpoint. Request `mcp:read` for inspection or `mcp:full` for changes, then approve the connection in OpenPost. Bind it to one workspace when possible.\n\n```txt\nhttps://app.openpost.social/mcp\n```\n\n**HTTP API:** create a token in **Settings → Personal → Developer access**. Use `api:read` or `api:write`; MCP and CLI scopes do not grant generic REST access. The token is shown once and expires within one year.\n\n```bash\ncurl https://app.openpost.social/api/v1/workspaces \\\n  -H \"Authorization: Bearer $OPENPOST_TOKEN\"\n```\n\n**CLI:** install the release binary, sign in through a browser, then select a workspace. The CLI stores its `cli:full` token in the operating-system keyring by default.\n\n```bash\ncurl -fsSL https://raw.githubusercontent.com/getopenpost/openpost/main/scripts/install-cli.sh | sh\nopenpost auth login https://app.openpost.social\n```\n\nUse a separate credential per client, choose the narrowest scope, and revoke access when the client no longer needs it.",
+    "sources": [
+      {
+        "title": "OpenPost API tokens",
+        "url": "https://docs.openpost.social/development/api-tokens"
+      },
+      {
+        "title": "OpenPost MCP setup",
+        "url": "https://docs.openpost.social/mcp/"
+      },
+      {
+        "title": "OpenPost CLI installation",
+        "url": "https://docs.openpost.social/cli/installation"
+      },
+      {
+        "title": "OpenPost CLI authentication",
+        "url": "https://docs.openpost.social/cli/authentication"
+      }
+    ],
+    "generatedAt": "2026-08-31",
+    "verified": true
+  },
+  "interfaces": [
+    {
+      "format": "mcp",
+      "name": "OpenPost MCP server",
+      "endpoint": "https://app.openpost.social/mcp",
+      "auth": "oauth",
+      "authHeader": "Authorization: Bearer {token}",
+      "docs": "https://docs.openpost.social/mcp/",
+      "note": "OAuth and manual tokens support mcp:read or mcp:full; access can be bound to one workspace.",
+      "origin": "vendor"
+    },
+    {
+      "format": "openapi",
+      "name": "OpenPost HTTP API",
+      "endpoint": "https://app.openpost.social/api/v1",
+      "spec": "https://docs.openpost.social/openapi.json",
+      "auth": "token",
+      "authHeader": "Authorization: Bearer {token}",
+      "docs": "https://docs.openpost.social/development/api-reference",
+      "note": "Use api:read or api:write. MCP and CLI token scopes are separate contracts.",
+      "origin": "vendor"
+    },
+    {
+      "format": "cli",
+      "name": "OpenPost CLI",
+      "auth": "token",
+      "install": "curl -fsSL https://raw.githubusercontent.com/getopenpost/openpost/main/scripts/install-cli.sh | sh",
+      "docs": "https://docs.openpost.social/cli/",
+      "note": "Browser or device login creates a cli:full token for the selected OpenPost instance.",
+      "origin": "vendor"
+    }
+  ],
+  "links": {
+    "homepage": "https://openpost.social",
+    "docs": "https://docs.openpost.social"
+  }
+}

--- a/curated/openpost.json
+++ b/curated/openpost.json
@@ -1,8 +1,8 @@
 {
   "slug": "openpost",
   "name": "OpenPost",
-  "tagline": "Create, adapt, schedule, and track social content with agents.",
-  "description": "OpenPost is a social publishing workspace for creating, adapting, scheduling, publishing, and tracking content across connected social accounts. Its HTTP API, MCP server, and CLI share the same workspace, scope, validation, and provider-readiness rules.",
+  "tagline": "Plan and publish social posts from an API, CLI, or MCP client.",
+  "description": "OpenPost lets people draft, adapt, schedule, publish, and track posts for connected social accounts. Its API, CLI, and MCP server use the same permissions and provider checks as the web app.",
   "domain": "openpost.social",
   "categories": [
     "social-media",
@@ -14,15 +14,15 @@
       {
         "type": "oauth2",
         "label": "MCP OAuth",
-        "note": "OAuth-aware MCP clients can request mcp:read or mcp:full and bind access to one workspace."
+        "note": "MCP clients can request read or full access and limit it to one workspace."
       },
       {
         "type": "token",
         "label": "OpenPost API token",
-        "note": "Revocable bearer tokens use interface-specific scopes and can be limited to one workspace."
+        "note": "API tokens are revocable, scoped, and can be limited to one workspace."
       }
     ],
-    "guide": "**Hosted MCP:** point an OAuth-aware client at the Hosted endpoint. Request `mcp:read` for inspection or `mcp:full` for changes, then approve the connection in OpenPost. Bind it to one workspace when possible.\n\n```txt\nhttps://app.openpost.social/mcp\n```\n\n**HTTP API:** create a token in **Settings → Personal → Developer access**. Use `api:read` or `api:write`; MCP and CLI scopes do not grant generic REST access. The token is shown once and expires within one year.\n\n```bash\ncurl https://app.openpost.social/api/v1/workspaces \\\n  -H \"Authorization: Bearer $OPENPOST_TOKEN\"\n```\n\n**CLI:** install the release binary, sign in through a browser, then select a workspace. The CLI stores its `cli:full` token in the operating-system keyring by default.\n\n```bash\ncurl -fsSL https://raw.githubusercontent.com/getopenpost/openpost/main/scripts/install-cli.sh | sh\nopenpost auth login https://app.openpost.social\n```\n\nUse a separate credential per client, choose the narrowest scope, and revoke access when the client no longer needs it.",
+    "guide": "**MCP with OAuth.** Add the Hosted MCP URL to your client. Use `mcp:read` to inspect data or `mcp:full` to make changes. OpenPost asks you to approve the connection and choose a workspace.\n\n```txt\nhttps://app.openpost.social/mcp\n```\n\n**HTTP API.** Create a token under **Settings → Personal → Developer access**. Choose `api:read` or `api:write` and limit it to one workspace when you can. MCP and CLI tokens do not work as REST API tokens.\n\n```bash\ncurl https://app.openpost.social/api/v1/workspaces \\\n  -H \"Authorization: Bearer $OPENPOST_TOKEN\"\n```\n\n**CLI.** Install the binary, sign in through your browser, and choose a workspace. OpenPost stores the CLI token in your system keyring. Use `--device` when the machine cannot open a browser.\n\n```bash\ncurl -fsSL https://raw.githubusercontent.com/getopenpost/openpost/main/scripts/install-cli.sh | sh\nopenpost auth login https://app.openpost.social\n```\n\nCreate a separate credential for each client and revoke it when you stop using that client.",
     "sources": [
       {
         "title": "OpenPost API tokens",
@@ -52,7 +52,7 @@
       "auth": "oauth",
       "authHeader": "Authorization: Bearer {token}",
       "docs": "https://docs.openpost.social/mcp/",
-      "note": "OAuth and manual tokens support mcp:read or mcp:full; access can be bound to one workspace.",
+      "note": "Use mcp:read for read-only access or mcp:full for changes. Both can be limited to one workspace.",
       "origin": "vendor"
     },
     {
@@ -63,7 +63,7 @@
       "auth": "token",
       "authHeader": "Authorization: Bearer {token}",
       "docs": "https://docs.openpost.social/development/api-reference",
-      "note": "Use api:read or api:write. MCP and CLI token scopes are separate contracts.",
+      "note": "Use api:read or api:write. MCP and CLI tokens do not work with the REST API.",
       "origin": "vendor"
     },
     {
@@ -72,7 +72,7 @@
       "auth": "token",
       "install": "curl -fsSL https://raw.githubusercontent.com/getopenpost/openpost/main/scripts/install-cli.sh | sh",
       "docs": "https://docs.openpost.social/cli/",
-      "note": "Browser or device login creates a cli:full token for the selected OpenPost instance.",
+      "note": "Browser or device login creates a CLI token for the selected OpenPost server.",
       "origin": "vendor"
     }
   ],

--- a/domains/openpost.social/integrations.json
+++ b/domains/openpost.social/integrations.json
@@ -1,0 +1,36 @@
+{
+  "description": "OpenPost is a social publishing workspace for creating, adapting, scheduling, publishing, and tracking posts across multiple social networks. It is available as a hosted service and as open-source software you can run on your own infrastructure.",
+  "discoveredAt": "2026-08-31T16:06:09.351Z",
+  "domain": "openpost.social",
+  "summary": "OpenPost exposes a workspace-scoped HTTP API, a hosted MCP server, and the openpost CLI. Each interface uses OpenPost-issued credentials and preserves the same workspace, scope, and provider checks as the web app.",
+  "surfaces": [
+    {
+      "authStatus": "required",
+      "name": "OpenPost HTTP API",
+      "slug": "openpost-http-api",
+      "spec": "https://docs.openpost.social/openapi.json",
+      "type": "http",
+      "url": "https://app.openpost.social/api/v1"
+    },
+    {
+      "authStatus": "required",
+      "name": "OpenPost MCP server",
+      "slug": "openpost-mcp-server",
+      "type": "mcp",
+      "url": "https://app.openpost.social/mcp"
+    },
+    {
+      "authStatus": "required",
+      "command": "openpost",
+      "name": "OpenPost CLI",
+      "packages": [
+        {
+          "identifier": "https://raw.githubusercontent.com/getopenpost/openpost/main/scripts/install-cli.sh",
+          "registryType": "other"
+        }
+      ],
+      "slug": "openpost-cli",
+      "type": "cli"
+    }
+  ]
+}

--- a/domains/openpost.social/integrations.json
+++ b/domains/openpost.social/integrations.json
@@ -1,8 +1,8 @@
 {
-  "description": "OpenPost is a social publishing workspace for creating, adapting, scheduling, publishing, and tracking posts across multiple social networks. It is available as a hosted service and as open-source software you can run on your own infrastructure.",
+  "description": "OpenPost lets people draft, adapt, schedule, publish, and track posts for connected social accounts. It is available as a hosted service or as self-hosted software.",
   "discoveredAt": "2026-08-31T16:06:09.351Z",
   "domain": "openpost.social",
-  "summary": "OpenPost exposes a workspace-scoped HTTP API, a hosted MCP server, and the openpost CLI. Each interface uses OpenPost-issued credentials and preserves the same workspace, scope, and provider checks as the web app.",
+  "summary": "OpenPost has a REST API, hosted MCP server, and CLI. They use scoped credentials and the same workspace and provider checks as the web app.",
   "surfaces": [
     {
       "authStatus": "required",


### PR DESCRIPTION
## What this adds

Adds OpenPost to integrations.sh with its three official integrations:

- REST API at `https://app.openpost.social/api/v1`
- hosted MCP server at `https://app.openpost.social/mcp`
- `openpost` CLI

The guide covers OAuth, API tokens, scopes, and workspace limits.

## Checks

- OpenAPI document loads and names the Hosted API URL
- MCP endpoint returns the expected auth challenge and OAuth metadata
- CLI install script loads from `getopenpost/openpost`
- `bun run build`
- `bun test`, 73 passed